### PR TITLE
#284 - GIT Support

### DIFF
--- a/dist/src/main/dist/conf/stabilizer.properties
+++ b/dist/src/main/dist/conf/stabilizer.properties
@@ -180,11 +180,12 @@ HAZELCAST_VERSION_SPEC=outofthebox
 # Comma separated list of additional GIT repositories to be fetched when HAZELCAST_VERSION_SPEC is set to GIT.
 #
 # Stabilizer will always fetch https://github.com/hazelcast/hazelcast
-# This options allows to specify additional repositories. Repository must be accessible for anonymous.
+# This property specifies additional repositories. You can use both remote and local repositories.
+# Remote repositories must be accessible for anonymous, local repositories must be accessible for current user.
 #
-# Default value: empty
+# Default value: empty, only the main Hazelcast repository is used by default.
 #
-#GIT_CUSTOM_REPOSITORIES=https://github.com/jerrinot/hazelcast.git,https://github.com/pveentjer/hazelcast.git
+#GIT_CUSTOM_REPOSITORIES=https://github.com/jerrinot/hazelcast.git,/home/jara/devel/oss/hazelcast
 
 # Path to a local Maven installation to use when HAZELCAST_VERSION_SPEC is set to GIT.
 #

--- a/dist/src/main/dist/conf/stabilizer.properties
+++ b/dist/src/main/dist/conf/stabilizer.properties
@@ -166,8 +166,12 @@ MACHINE_SPEC=hardwareId=c3.xlarge,imageId=us-east-1/ami-1b3b2472
 #                             on the agent machine.
 #   bringmyown              : if you want to bring your own dependencies, for more information checkout out the
 #                             --workerClassPath setting on the Controller.
-#   git=sha1-hash           : if you want Stabilizer to build a specific GIT revision of Hazelcast, e.g.
-#                                   git=f0288f713
+#   git=version             : if you want Stabilizer to use a specific version of Hazelcast from GIT, e.g.:
+#                                   git=f0288f713    to build a specific revision
+#                                   git=v3.2.3       to build a version from a GIT tag
+#                                   git=myRepository/myBranch - to build a version from a branch in a specific repository.
+#   Use GIT_CUSTOM_REPOSITORIES to specify custom repositories. The main Hazelcast repository is always named "origin".
+
 HAZELCAST_VERSION_SPEC=outofthebox
 
 # When HAZELCAST_VERSION_SPEC is set to GIT then it will download Hazelcast sources to this directory.
@@ -185,7 +189,7 @@ HAZELCAST_VERSION_SPEC=outofthebox
 #
 # Default value: empty, only the main Hazelcast repository is used by default.
 #
-#GIT_CUSTOM_REPOSITORIES=https://github.com/jerrinot/hazelcast.git,/home/jara/devel/oss/hazelcast
+#GIT_CUSTOM_REPOSITORIES=myFork=https://github.com/jerrinot/hazelcast.git,localRepo=/home/jara/devel/oss/hazelcast
 
 # Path to a local Maven installation to use when HAZELCAST_VERSION_SPEC is set to GIT.
 #

--- a/dist/src/main/dist/conf/stabilizer.properties
+++ b/dist/src/main/dist/conf/stabilizer.properties
@@ -166,7 +166,32 @@ MACHINE_SPEC=hardwareId=c3.xlarge,imageId=us-east-1/ami-1b3b2472
 #                             on the agent machine.
 #   bringmyown              : if you want to bring your own dependencies, for more information checkout out the
 #                             --workerClassPath setting on the Controller.
+#   git=sha1-hash           : if you want Stabilizer to build a specific GIT revision of Hazelcast, e.g.
+#                                   git=f0288f713
 HAZELCAST_VERSION_SPEC=outofthebox
+
+# When HAZELCAST_VERSION_SPEC is set to GIT then it will download Hazelcast sources to this directory.
+#
+# Default value: $HOME/.hazelcast-build/
+#
+#
+#GIT_BUILD_DIR=/home/joe/.hazelcast-build/
+
+# Comma separated list of additional GIT repositories to be fetched when HAZELCAST_VERSION_SPEC is set to GIT.
+#
+# Stabilizer will always fetch https://github.com/hazelcast/hazelcast
+# This options allows to specify additional repositories. Repository must be accessible for anonymous.
+#
+# Default value: empty
+#
+#GIT_CUSTOM_REPOSITORIES=https://github.com/jerrinot/hazelcast.git,https://github.com/pveentjer/hazelcast.git
+
+# Path to a local Maven installation to use when HAZELCAST_VERSION_SPEC is set to GIT.
+#
+# Default value: Stabilizer expects 'mvn' binary to be available on a PATH.
+#
+#MVN_EXECUTABLE=/usr/bin/mvn
+
 
 # =====================================================================
 # JDK Installation

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,7 @@
         <maven.gpg.plugin.version>1.4</maven.gpg.plugin.version>
         <jsr107.api.version>1.0.0</jsr107.api.version>
         <hdr-histogram.version>2.0.1</hdr-histogram.version>
+        <jgit.version>3.5.3.201412180710-r</jgit.version>
     </properties>
 
     <modules>

--- a/stabilizer/pom.xml
+++ b/stabilizer/pom.xml
@@ -12,6 +12,11 @@
     <artifactId>stabilizer</artifactId>
 
     <dependencies>
+        <dependency>
+            <groupId>org.eclipse.jgit</groupId>
+            <artifactId>org.eclipse.jgit</artifactId>
+            <version>${jgit.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>javax.cache</groupId>

--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/Utils.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/Utils.java
@@ -15,6 +15,7 @@
  */
 package com.hazelcast.stabilizer;
 
+import com.google.common.io.Files;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.stabilizer.coordinator.Coordinator;
@@ -534,6 +535,11 @@ public final class Utils {
         System.exit(1);
     }
 
+    public static void exitWithError(ILogger logger, String msg, Throwable t) {
+        String throwableString = throwableToString(t);
+        exitWithError(log, msg + "\n" + throwableString);
+    }
+
 
     private Utils() {
     }
@@ -647,5 +653,22 @@ public final class Utils {
         }
 
         return files;
+    }
+
+    public static void copyFilesToDirectory(File[] sourceFiles, File targetDirectory) {
+        for (File sourceFile : sourceFiles) {
+            copyFileToDirectory(sourceFile, targetDirectory);
+        }
+    }
+
+    public static void copyFileToDirectory(File sourceFile, File targetDirectory) {
+        File targetFile = Utils.newFile(targetDirectory, sourceFile.getName());
+        try {
+            Files.copy(sourceFile, targetFile);
+        } catch (IOException e) {
+            String errorMessage = format("Error while copying file from %s to %s",
+                    sourceFile.getAbsolutePath(), targetFile.getAbsolutePath());
+            exitWithError(log, errorMessage, e);
+        }
     }
 }

--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/common/StabilizerProperties.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/common/StabilizerProperties.java
@@ -3,6 +3,7 @@ package com.hazelcast.stabilizer.common;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.stabilizer.Utils;
+import com.hazelcast.stabilizer.provisioner.HazelcastJars;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -23,11 +24,13 @@ public class StabilizerProperties {
     private final static ILogger log = Logger.getLogger(StabilizerProperties.class);
 
     private final Properties properties = new Properties();
+    private String hazelcastVersionSpec = "outofthebox";
 
     public StabilizerProperties() {
         File defaultPropsFile = newFile(getStablizerHome(), "conf", "stabilizer.properties");
         log.finest("Loading default stabilizer.properties from: " + defaultPropsFile.getAbsolutePath());
         load(defaultPropsFile);
+        hazelcastVersionSpec = get("HAZELCAST_VERSION_SPEC", "outofthebox");
     }
 
     public String getUser() {
@@ -39,7 +42,14 @@ public class StabilizerProperties {
     }
 
     public String getHazelcastVersionSpec() {
-        return get("HAZELCAST_VERSION_SPEC", "outofthebox");
+        return hazelcastVersionSpec;
+    }
+
+    public void forceGit(String gitRevision) {
+        if (gitRevision != null && !gitRevision.isEmpty()) {
+            hazelcastVersionSpec = HazelcastJars.GIT_VERSION_PREFIX + gitRevision;
+            log.info("Overriding Hazelcast version to GIT revision " + gitRevision);
+        }
     }
 
     /**

--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/provisioner/HazelcastJars.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/provisioner/HazelcastJars.java
@@ -19,6 +19,8 @@ import static java.lang.String.format;
  * Responsible for uploading the correct Hazelcast jars to the agents/workers.
  */
 public class HazelcastJars {
+    public static final String GIT_VERSION_PREFIX = "git=";
+    public static final String MAVEN_VERSION_PREFIX = "maven=";
 
     private final static ILogger log = Logger.getLogger(HazelcastJars.class);
     private final Bash bash;
@@ -48,8 +50,8 @@ public class HazelcastJars {
             //we don't need to do anything.
         } else if (versionSpec.equals("bringmyown")) {
             //we don't need to do anything
-        } else if (versionSpec.startsWith("maven=")) {
-            String version = versionSpec.substring(6);
+        } else if (versionSpec.startsWith(MAVEN_VERSION_PREFIX)) {
+            String version = versionSpec.substring(MAVEN_VERSION_PREFIX.length());
             if (eejars) {
                 mavenRetrieve("hazelcast-enterprise", version);
                 mavenRetrieve("hazelcast-enterprise-client", version);
@@ -57,11 +59,11 @@ public class HazelcastJars {
                 mavenRetrieve("hazelcast", version);
                 mavenRetrieve("hazelcast-client", version);
             }
-        } else if (versionSpec.startsWith("git=")) {
+        } else if (versionSpec.startsWith(GIT_VERSION_PREFIX)) {
             if (eejars) {
                 exitWithError(log, "Hazelcast Enterprise is currently not supported when HAZELCAST_VERSION_SPEC is set to GIT.");
             }
-            String revision = versionSpec.substring("git=".length());
+            String revision = versionSpec.substring(GIT_VERSION_PREFIX.length());
             gitRetrieve(revision);
         } else {
             log.severe("Unrecognized version spec:" + versionSpec);

--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/provisioner/ProvisionerCli.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/provisioner/ProvisionerCli.java
@@ -15,10 +15,12 @@ public class ProvisionerCli {
     public final OptionParser parser = new OptionParser();
 
     private final OptionSpec<String> gitSpec = parser.accepts("git",
-            "Override the HAZELCAST_VERSION_SPEC property and force Provisioner to build " +
+            "Overrides the HAZELCAST_VERSION_SPEC property and forces Provisioner to build " +
                     "Hazelcast JARs from a given GIT version. This makes it easier to run a test " +
                     "with different versions of Hazelcast. \n " +
-                    "E.g. --git f0288f713 will use the Git revision f0288f713.")
+                    "E.g. --git f0288f713                to use the Git revision f0288f713 \n" +
+                    "     --git myRepository/myBranch    to use branch myBranch from a repository myRepository. " +
+                    "You can specify custom repositories in stabilizer.properties.")
             .withRequiredArg().ofType(String.class);
 
     public final OptionSpec restartSpec = parser.accepts("restart",

--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/provisioner/ProvisionerCli.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/provisioner/ProvisionerCli.java
@@ -14,6 +14,13 @@ public class ProvisionerCli {
 
     public final OptionParser parser = new OptionParser();
 
+    private final OptionSpec<String> gitSpec = parser.accepts("git",
+            "Override the HAZELCAST_VERSION_SPEC property and force Provisioner to build " +
+                    "Hazelcast JARs from a given GIT version. This makes it easier to run a test " +
+                    "with different versions of Hazelcast. \n " +
+                    "E.g. --git f0288f713 will use the Git revision f0288f713.")
+            .withRequiredArg().ofType(String.class);
+
     public final OptionSpec restartSpec = parser.accepts("restart",
             "Restarts all agents");
 
@@ -48,7 +55,7 @@ public class ProvisionerCli {
     ).withRequiredArg().ofType(String.class);
 
     private final OptionSpec<Boolean> enterpriseEnabledSpec = parser.accepts("enterpriseEnabled",
-            "use hazelcast enterprise edition jars")
+            "Use hazelcast enterprise edition JARs.")
             .withRequiredArg().ofType(Boolean.class).defaultsTo(false);
 
     private final Provisioner provisioner;
@@ -72,8 +79,13 @@ public class ProvisionerCli {
         }
 
         provisioner.props.init(getPropertiesFile());
-        provisioner.init();
 
+        if (options.has(gitSpec)) {
+            String git = options.valueOf(gitSpec);
+            provisioner.props.forceGit(git);
+        }
+
+        provisioner.init();
         if (options.has(restartSpec)) {
             boolean enterpriseEnabled = options.valueOf(enterpriseEnabledSpec);
             provisioner.restart(enterpriseEnabled);

--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/provisioner/git/BuildSupport.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/provisioner/git/BuildSupport.java
@@ -1,0 +1,79 @@
+package com.hazelcast.stabilizer.provisioner.git;
+
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+import com.hazelcast.stabilizer.Utils;
+import com.hazelcast.stabilizer.provisioner.Bash;
+
+import java.io.File;
+
+import static com.hazelcast.stabilizer.Utils.exitWithError;
+import static java.lang.String.format;
+
+public class BuildSupport {
+    private final static ILogger log = Logger.getLogger(BuildSupport.class);
+
+    private final Bash bash;
+    private final HazelcastJARFinder jarFinder;
+    private final String mavenExecutable;
+
+    public BuildSupport(Bash bash, HazelcastJARFinder jarFinder) {
+        this(bash, jarFinder, null);
+    }
+
+    public BuildSupport(Bash bash, HazelcastJARFinder jarFinder, String pathToMaven) {
+        this.bash = bash;
+        this.jarFinder = jarFinder;
+        this.mavenExecutable = getMavenExecutable(pathToMaven);
+    }
+
+    private String getMavenExecutable(String pathToMaven) {
+        if (pathToMaven == null || pathToMaven.isEmpty()) {
+            return "mvn";
+        } else {
+            File maven = new File(pathToMaven);
+            if (!maven.exists()) {
+                exitWithError(log, "Specified path " + pathToMaven + " to Maven doesn't exist.");
+            }
+            if (maven.isDirectory()) {
+                maven = Utils.newFile(pathToMaven, "mvn");
+            }
+            checkIsValidMavenExecutable(pathToMaven, maven);
+            return maven.getAbsolutePath();
+        }
+    }
+
+    private void checkIsValidMavenExecutable(String pathToMaven, File mavenExec) {
+        if (!mavenExec.isFile()) {
+            exitWithError(log, "Specified path " + pathToMaven + " to Maven doesn't contains 'mvn' executable.");
+        }
+        if (!mavenExec.canExecute()) {
+            exitWithError(log, "Specified path " + pathToMaven + " to Maven contains 'mvn' which is not executable.");
+        }
+    }
+
+    public File[] build(File pathToSource) {
+        String absolutePath = pathToSource.getAbsolutePath();
+        log.info("Building Hazelcast from sources at " + absolutePath);
+
+        String cmd = getBuildCommand(absolutePath);
+        bash.execute(cmd);
+
+        File[] jars = jarFinder.find(pathToSource);
+        logFilenames(jars);
+        return jars;
+    }
+
+    private String getBuildCommand(String absolutePath) {
+        //TODO: This is probably not very safe, some escaping is probably necessary
+        return format("cd %s ; %s clean install -DskipTests", absolutePath, mavenExecutable);
+    }
+
+    private void logFilenames(File[] jars) {
+        StringBuilder sb = new StringBuilder("Hazelcast has been built successfully. JARs found: \n");
+        for (File jar : jars) {
+            sb.append(jar.getName()).append('\n');
+        }
+    }
+
+}

--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/provisioner/git/GitRepository.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/provisioner/git/GitRepository.java
@@ -1,0 +1,68 @@
+package com.hazelcast.stabilizer.provisioner.git;
+
+public class GitRepository {
+    private final String name;
+    private final String url;
+
+    public GitRepository(String name, String url) {
+        this.name = name;
+        this.url = url;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public static GitRepository fromString(String repositoryString) {
+        if (repositoryString == null || repositoryString.isEmpty()) {
+            throw new IllegalArgumentException("Repository String cannot be empty.");
+        }
+        String[] repoSplit = repositoryString.split("=");
+        if (repoSplit.length != 2) {
+            throw new IllegalArgumentException("Invalid Repository " + repositoryString +
+                    "\n Repository has to be in this format: <name>=<url>. \n" +
+                    "E.g. jaromir=https://github.com/hazelcast/hazelcast-stabilizer.git");
+        }
+        String name = repoSplit[0].trim();
+        if (name.isEmpty()) {
+            throw new IllegalArgumentException("Repository '" + repositoryString + "' has empty name.");
+        }
+        String url = repoSplit[1].trim();
+        if (url.isEmpty()) {
+            throw new IllegalArgumentException("Repository '" + repositoryString + "' has URL name.");
+        }
+        return new GitRepository(name, url);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        GitRepository that = (GitRepository) o;
+
+        if (name != null ? !name.equals(that.name) : that.name != null) return false;
+        if (url != null ? !url.equals(that.url) : that.url != null) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = name != null ? name.hashCode() : 0;
+        result = 31 * result + (url != null ? url.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "GitRepository{" +
+                "name='" + name + '\'' +
+                ", url='" + url + '\'' +
+                '}';
+    }
+}

--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/provisioner/git/GitSupport.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/provisioner/git/GitSupport.java
@@ -1,0 +1,234 @@
+package com.hazelcast.stabilizer.provisioner.git;
+
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+import com.hazelcast.stabilizer.Utils;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.ResetCommand;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.errors.RepositoryNotFoundException;
+import org.eclipse.jgit.lib.Constants;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.lib.StoredConfig;
+import org.eclipse.jgit.transport.FetchResult;
+import org.eclipse.jgit.transport.RefSpec;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import static com.hazelcast.stabilizer.Utils.exitWithError;
+
+
+public class GitSupport {
+    private static final String HAZELCAST_MAIN_REPO_URL = "https://github.com/hazelcast/hazelcast.git";
+    private final static ILogger log = Logger.getLogger(GitSupport.class);
+    public static final String CUSTOM_REPOSITORY_PREFIX = "custom";
+
+    private final BuildSupport buildSupport;
+    private final File baseDir;
+    private final Set<String> customRepositories;
+
+    public GitSupport(BuildSupport buildSupport) {
+        this(buildSupport, null);
+    }
+
+    public GitSupport(BuildSupport buildSupport, String customRepositories) {
+        this(buildSupport, customRepositories, null);
+    }
+
+    public GitSupport(BuildSupport buildSupport, String customRepositories, String basePath) {
+        this.buildSupport = buildSupport;
+        this.baseDir = getBaseDir(basePath);
+        this.customRepositories = getCustomRepositories(customRepositories);
+    }
+
+    public File[] checkout(String revision) {
+        File srcDirectory = getOrCreateSourceDirectory();
+        String fullSha1 = fetchSources(srcDirectory, revision);
+
+        File buildCache = getCacheDirectory(fullSha1);
+        if (!buildCache.exists()) {
+            buildAndCache(srcDirectory, buildCache);
+        } else {
+            log.info("Hazelcast JARs found in build-cache " + buildCache.getAbsolutePath());
+        }
+        return buildCache.listFiles();
+    }
+
+    private Set<String> getCustomRepositories(String customRepositories) {
+        if (customRepositories == null || customRepositories.isEmpty()) {
+            return Collections.emptySet();
+        }
+        String[] repositoriesArray = customRepositories.split(",");
+        Set<String> repositories = new HashSet<String>(repositoriesArray.length);
+        for (String repository : repositoriesArray) {
+            String normalized = repository.trim();
+            if (!normalized.isEmpty()) {
+                repositories.add(normalized);
+            }
+        }
+        return Collections.unmodifiableSet(repositories);
+    }
+
+    private File getDefaultBaseDir() {
+        File homeDir = new File(System.getProperty("user.home"));
+        return Utils.newFile(homeDir, ".hazelcast-build");
+    }
+
+    private void syncRemoteRepositories(Git git) throws IOException {
+        StoredConfig config = git.getRepository().getConfig();
+        Set<String> customRepositoriesCopy = new HashSet<String>(customRepositories);
+
+        Set<String> existingRemoteRepoName = config.getSubsections("remote");
+        int customRepositoriesCounter = 0;
+        for (String remoteName : existingRemoteRepoName) {
+            String url = config.getString("remote", remoteName, "url");
+            customRepositoriesCopy.remove(url);
+            if (isCustomRepository(remoteName)) {
+                customRepositoriesCounter++;
+            }
+        }
+
+        for (String url : customRepositoriesCopy) {
+            String repositoryName = CUSTOM_REPOSITORY_PREFIX + customRepositoriesCounter;
+            log.info("Adding a new custom repository " + url);
+
+            customRepositoriesCounter++;
+            config.setString("remote", repositoryName, "url", url);
+            RefSpec refSpec = new RefSpec()
+                    .setForceUpdate(true)
+                    .setSourceDestination(Constants.R_HEADS + "*", Constants.R_REMOTES + repositoryName + "/*");
+            config.setString("remote", repositoryName, "fetch", refSpec.toString());
+        }
+        config.save();
+    }
+
+    private boolean isCustomRepository(String remoteName) {
+        return remoteName.startsWith(CUSTOM_REPOSITORY_PREFIX);
+    }
+
+    private String fetchSources(File path, String revision) {
+        Git git = null;
+        String fullSha1 = null;
+        try {
+            git = cloneIfNecessary(path);
+            syncRemoteRepositories(git);
+            fetchAllRepositories(git);
+            fullSha1 = checkoutRevision(git, revision);
+        } catch (GitAPIException e) {
+            exitWithError(log, "Error while fetching sources from GIT", e);
+        } catch (IOException e) {
+            exitWithError(log, "Error while fetching sources from GIT", e);
+        } finally {
+            if (git != null) {
+                git.close();
+            }
+        }
+        return fullSha1;
+    }
+
+    private File getBaseDir(String basePath) {
+        File baseDir;
+        if (basePath == null) {
+            baseDir = getDefaultBaseDir();
+            if (baseDir.exists()) {
+                if (!baseDir.isDirectory()) {
+                    exitWithError(log, "Default directory for building Hazelcast from GIT is "
+                            + baseDir.getAbsolutePath() + ". This path already exists, but it isn't a directory. " +
+                            "Please configure the directory explicitly via stabilizer.properties or remove the existing path.");
+                } else if (!baseDir.canWrite()) {
+                    exitWithError(log, "Default directory for building Hazelcast from GIT is "
+                            + baseDir.getAbsolutePath() + ". This path already exists, but it isn't writable. " +
+                            "Please configure the directory explicitly via stabilizer.properties or check access rights.");
+                }
+            }
+        } else {
+            baseDir = new File(basePath);
+            if (baseDir.exists()) {
+                if (!baseDir.isDirectory()) {
+                    exitWithError(log, "Directory for building Hazelcast from GIT is "
+                            + baseDir.getAbsolutePath() + ". This path already exists, but it isn't a directory. ");
+                } else if (!baseDir.canWrite()) {
+                    exitWithError(log, "Directory for building Hazelcast from GIT is "
+                            + baseDir.getAbsolutePath() + ". This path already exists, but it isn't writable. ");
+                }
+            }
+        }
+        if (!baseDir.exists()) {
+            baseDir.mkdirs();
+            if (!baseDir.exists()) {
+                exitWithError(log, "Cannot create a directory for building Hazelcast form GIT. Directory is set to "
+                        + baseDir.getAbsolutePath() + ". Please check access rights.");
+            }
+        }
+        return baseDir;
+    }
+
+    private File getCacheDirectory(String fullSha1) {
+        return Utils.newFile(baseDir, "build-cache", fullSha1);
+    }
+
+    private File getOrCreateSourceDirectory() {
+        File src = Utils.newFile(baseDir, "src");
+        src.mkdirs();
+        return src;
+    }
+
+    private void fetchAllRepositories(Git git) throws GitAPIException {
+        Repository repository = git.getRepository();
+        Set<String> remotes = repository.getRemoteNames();
+        for (String remoteRepository : remotes) {
+            git.fetch().setRemote(remoteRepository).call();
+
+        }
+    }
+
+    private void buildAndCache(File src, File buildCache) {
+        File[] files = buildSupport.build(src);
+        buildCache.mkdirs();
+        Utils.copyFilesToDirectory(files, buildCache);
+    }
+
+    private Git cloneIfNecessary(File src) throws GitAPIException, IOException {
+        Git git;
+        if (!isValidLocalRepository(src)) {
+            log.info("Cloning Hazelcast GIT repository to " + src.getAbsolutePath() + " This might take a while.");
+            git = Git.cloneRepository().setURI(HAZELCAST_MAIN_REPO_URL).setDirectory(src).call();
+        } else {
+            git = Git.open(src);
+        }
+        return git;
+    }
+
+    private String checkoutRevision(Git git, String revision) throws GitAPIException, IOException {
+        resetHard(git);
+        git.checkout().setForce(true).setName(revision).setStartPoint(revision).call();
+        return git.getRepository().resolve(revision).toObjectId().name();
+    }
+
+    private void resetHard(Git git) throws GitAPIException {
+        git.reset().setMode(ResetCommand.ResetType.HARD).call();
+    }
+
+    private boolean isValidLocalRepository(File repository) {
+        boolean result = false;
+        Git git = null;
+        try {
+            git = Git.open(repository);
+            result = true;
+        } catch (RepositoryNotFoundException e) {
+            result = false;
+        } catch (IOException e) {
+            result = false;
+        } finally {
+            if (git != null) {
+                git.close();
+            }
+        }
+        return result;
+    }
+
+}

--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/provisioner/git/HazelcastFilenameFilter.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/provisioner/git/HazelcastFilenameFilter.java
@@ -1,0 +1,27 @@
+package com.hazelcast.stabilizer.provisioner.git;
+
+import java.io.File;
+import java.io.FilenameFilter;
+
+public class HazelcastFilenameFilter implements FilenameFilter {
+    @Override
+    public boolean accept(File dir, String name) {
+        if (!name.endsWith(".jar")) {
+            return false;
+        }
+        if (!name.contains("hazelcast")) {
+            return false;
+        }
+        if (name.contains("sources")) {
+            return false;
+        }
+        if (name.contains("tests")) {
+            return false;
+        }
+        if (name.contains("original")) {
+            return false;
+        }
+        return true;
+    }
+
+}

--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/provisioner/git/HazelcastJARFinder.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/provisioner/git/HazelcastJARFinder.java
@@ -1,0 +1,57 @@
+package com.hazelcast.stabilizer.provisioner.git;
+
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.stabilizer.Utils;
+
+import java.io.File;
+
+import static com.hazelcast.stabilizer.Utils.exitWithError;
+
+public class HazelcastJARFinder {
+    private final static ILogger log = com.hazelcast.logging.Logger.getLogger(HazelcastJARFinder.class);
+
+    public File[] find(File path) {
+        File memberPath = Utils.newFile(path, "hazelcast", "target");
+        File memberJar = findJarAtPath(memberPath);
+        File clientPath = Utils.newFile(path, "hazelcast-client", "target");
+        File clientJar = findJarAtPath(clientPath);
+
+        return new File[]{memberJar, clientJar};
+    }
+
+    private File findJarAtPath(File memberPath) {
+        checkPathExist(memberPath);
+        return findHazelcastJar(memberPath);
+    }
+
+    private File findHazelcastJar(File memberPathToTarget) {
+        File[] files = memberPathToTarget.listFiles(new HazelcastFilenameFilter());
+        checkIsSingleFile(files, memberPathToTarget);
+        return files[0];
+    }
+
+    private void checkIsSingleFile(File[] files, File memberPathToTarget) {
+        if (files.length == 0) {
+            exitWithError(log, "Path " + memberPathToTarget + " doesn't contain Hazelcast JAR.");
+        }
+        if (files.length > 1) {
+            StringBuilder sb = new StringBuilder("Path ")
+                    .append(memberPathToTarget.getAbsolutePath())
+                    .append("contains more than one JAR which seems to be Hazelcast JAR: \n");
+            for (File file : files) {
+                sb.append(file.getName()).append('\n');
+            }
+            sb.append("This is probably a bug, please create a new bug report with this message. " +
+                    "https://github.com/hazelcast/hazelcast-stabilizer/issues/new");
+            exitWithError(log, sb.toString());
+        }
+    }
+
+    private void checkPathExist(File memberPathToTarget) {
+        if (!memberPathToTarget.exists()) {
+            exitWithError(log, "Cannot find a path to Hazelcast JAR. It should be at "
+                    + memberPathToTarget.getAbsolutePath() + ", but the path doesn't exist.");
+        }
+    }
+
+}

--- a/stabilizer/src/test/java/com/hazelcast/stabilizer/provisioner/git/BuildSupportTest.java
+++ b/stabilizer/src/test/java/com/hazelcast/stabilizer/provisioner/git/BuildSupportTest.java
@@ -1,0 +1,39 @@
+package com.hazelcast.stabilizer.provisioner.git;
+
+import com.hazelcast.stabilizer.provisioner.Bash;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.io.File;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+public class BuildSupportTest {
+
+    private Bash mockBash;
+    private HazelcastJARFinder mockHazelcastJARFinder;
+
+    private final File basePath = new File("/foo/bar");
+    private final File[] expectedFiles = new File[]{new File("member.jar"), new File("client.jar")};
+
+    @Before
+    public void setUp() {
+        mockBash = mock(Bash.class);
+        mockHazelcastJARFinder = mock(HazelcastJARFinder.class);
+
+        when(mockHazelcastJARFinder.find(basePath))
+                .thenReturn(expectedFiles);
+    }
+
+    @Test
+    public void build_defaultPathToMaven() {
+        BuildSupport buildSupport = new BuildSupport(mockBash, mockHazelcastJARFinder);
+        File[] returnedFiles = buildSupport.build(basePath);
+
+        verify(mockBash).execute("cd /foo/bar ; mvn clean install -DskipTests");
+        assertArrayEquals(expectedFiles, returnedFiles);
+    }
+
+}

--- a/stabilizer/src/test/java/com/hazelcast/stabilizer/provisioner/git/HazelcastFilenameFilterTest.java
+++ b/stabilizer/src/test/java/com/hazelcast/stabilizer/provisioner/git/HazelcastFilenameFilterTest.java
@@ -1,0 +1,62 @@
+package com.hazelcast.stabilizer.provisioner.git;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+
+import static org.junit.Assert.*;
+
+public class HazelcastFilenameFilterTest {
+    private HazelcastFilenameFilter filter;
+    private File dir;
+
+    @Before
+    public void setUp() {
+        filter = new HazelcastFilenameFilter();
+        dir = null;
+    }
+
+    @Test
+    public void accept_mustEndsWithJAR() {
+        assertDeniesName("hazelcast-client-3.5-SNAPSHOT");
+    }
+
+    @Test
+    public void accept_mustContainsHazelcast() {
+        assertDeniesName("client-3.5-SNAPSHOT.jar");
+    }
+
+    @Test
+    public void accept_doesntAcceptSources() {
+        assertDeniesName("hazelcast-3.5-SNAPSHOT-sources.jar");
+    }
+
+    @Test
+    public void accept_doesntAcceptTests() {
+        assertDeniesName("hazelcast-3.5-SNAPSHOT-tests.jar");
+    }
+
+    @Test
+    public void accept_doesntAcceptOriginal() {
+        assertDeniesName("original-hazelcast-3.5-SNAPSHOT.jar");
+    }
+
+    @Test
+    public void accept_member() {
+        assertAcceptsName("hazelcast-3.5-SNAPSHOT.jar");
+    }
+
+    @Test
+    public void accept_client() {
+        assertAcceptsName("hazelcast-client-3.5-SNAPSHOT.jar");
+    }
+
+    private void assertAcceptsName(String filename) {
+        assertTrue(filter.accept(dir, filename));
+    }
+
+    private void assertDeniesName(String filename) {
+        assertFalse(filter.accept(dir, filename));
+    }
+}


### PR DESCRIPTION
Hazelcast GIT revision can be specified via the HAZELCAST_VERSION_SPEC in stabilizer.properties.


```
# for a specific revision
HAZELCAST_VERSION_SPEC=git=f0288f713

# for a HEAD of a branch 'myBranch' in a repository 'myRepo'
HAZELCAST_VERSION_SPEC=git=myRepo/myBranch

# for a tag v3.2.3
HAZELCAST_VERSION_SPEC=git=v3.2.3

```

--git option can used to enforce a specific Hazelcast version via command line. It overrides the HAZELCAST_VERSION_SPEC property. It's a convenient way to enforce Hazelcast version from shell scripts.
```
provisioner --restart --git f0288f713
or
provisioner --restart --git myRepo/myBranch
```

Stabilizer will always fetch the main Hazelcast repository https://github.com/hazelcast/hazelcast.git. Name of this repository is always 'origin'.

Additional repositories can be specified via the GIT_CUSTOM_REPOSITORIES property in stabilizer.properties
```
GIT_CUSTOM_REPOSITORIES=myFork=https://github.com/jerrinot/hazelcast.git,localRepo=/home/jara/devel/oss/hazelcast
```

Stabilizer expects 'mvn' command to be available on a search path. If that's not the case you can use the MVN_EXECUTABLE property to specify a full path to Maven. 

Source code and build artefacts are cached in $HOME/.hazelcast-build/ 
Use the GIT_BUILD_DIR property to use a custom path.

Missing features:
- Hazelcast Enterprise Support. It should be fairly easy to add it.