### PR TITLE
Reduced Hazelcast dependencies in Stabilizer core module

### DIFF
--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/Utils.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/Utils.java
@@ -16,12 +16,11 @@
 package com.hazelcast.stabilizer;
 
 import com.google.common.io.Files;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.stabilizer.coordinator.Coordinator;
 import joptsimple.OptionSet;
 import joptsimple.OptionSpec;
 import org.apache.commons.lang3.text.StrSubstitutor;
+import org.apache.log4j.Logger;
 
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
@@ -75,7 +74,7 @@ public final class Utils {
     private static final String DEFAULT_DELIMITER = ", ";
     private static final String EXCEPTION_SEPARATOR = "------ End remote and begin local stack-trace ------";
     private static final String USER_HOME = System.getProperty("user.home");
-    private static final ILogger log = Logger.getLogger(Utils.class);
+    private static final Logger log = Logger.getLogger(Utils.class);
 
     private static volatile String hostAddress;
 
@@ -530,16 +529,15 @@ public final class Utils {
         LockSupport.parkNanos(nanos);
     }
 
-    public static void exitWithError(ILogger logger, String msg) {
-        logger.severe(msg);
+    public static void exitWithError(Logger logger, String msg) {
+        logger.fatal(msg);
         System.exit(1);
     }
 
-    public static void exitWithError(ILogger logger, String msg, Throwable t) {
+    public static void exitWithError(Logger logger, String msg, Throwable t) {
         String throwableString = throwableToString(t);
-        exitWithError(log, msg + "\n" + throwableString);
+        exitWithError(logger, msg + "\n" + throwableString);
     }
-
 
     private Utils() {
     }

--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/common/AgentsFile.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/common/AgentsFile.java
@@ -1,7 +1,7 @@
 package com.hazelcast.stabilizer.common;
 
-import com.hazelcast.logging.ILogger;
 import com.hazelcast.stabilizer.Utils;
+import org.apache.log4j.Logger;
 
 import java.io.File;
 import java.util.LinkedList;
@@ -26,7 +26,7 @@ import static java.lang.String.format;
  */
 public class AgentsFile {
 
-    private final static ILogger log = com.hazelcast.logging.Logger.getLogger(AgentsFile.class);
+    private final static Logger log = Logger.getLogger(AgentsFile.class);
 
     public static void save(File agentsFile, List<AgentAddress> addresses) {
         StringBuffer sb = new StringBuffer();
@@ -70,8 +70,8 @@ public class AgentsFile {
                     pairs.add(new AgentAddress(chunks[0], chunks[1]));
                     break;
                 default:
-                    log.severe(format("Line %s of file %s is invalid, it should contain 1 or 2 addresses separated by a comma, " +
-                            "but contains %s", lineNumber, agentFile, chunks.length));
+                    log.fatal(format("Line %s of file %s is invalid, it should contain 1 or 2 addresses separated by a "
+                            + "comma, but contains %s", lineNumber, agentFile, chunks.length));
                     System.exit(1);
                     break;
             }

--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/common/StabilizerProperties.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/common/StabilizerProperties.java
@@ -1,9 +1,8 @@
 package com.hazelcast.stabilizer.common;
 
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.stabilizer.Utils;
 import com.hazelcast.stabilizer.provisioner.HazelcastJars;
+import org.apache.log4j.Logger;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -21,14 +20,14 @@ import static java.lang.String.format;
  * is configured, it will override the properties from the default.
  */
 public class StabilizerProperties {
-    private final static ILogger log = Logger.getLogger(StabilizerProperties.class);
+    private final static Logger log = Logger.getLogger(StabilizerProperties.class);
 
     private final Properties properties = new Properties();
     private String forcedHazelcastVersionSpec;
 
     public StabilizerProperties() {
         File defaultPropsFile = newFile(getStablizerHome(), "conf", "stabilizer.properties");
-        log.finest("Loading default stabilizer.properties from: " + defaultPropsFile.getAbsolutePath());
+        log.debug("Loading default stabilizer.properties from: " + defaultPropsFile.getAbsolutePath());
         load(defaultPropsFile);
     }
 
@@ -68,7 +67,7 @@ public class StabilizerProperties {
             if (fallbackPropsFile.exists()) {
                 file = fallbackPropsFile;
             } else {
-                log.warning(format("%s is not found, relying on defaults", fallbackPropsFile));
+                log.warn(format("%s is not found, relying on defaults", fallbackPropsFile));
             }
         }
 
@@ -151,8 +150,8 @@ public class StabilizerProperties {
             Utils.exitWithError(log, format("Can't find %s file %s", property, value));
         }
 
-        if (log.isFinestEnabled()) {
-            log.finest("Loading " + property + " from file: " + file.getAbsolutePath());
+        if (log.isDebugEnabled()) {
+            log.debug("Loading " + property + " from file: " + file.getAbsolutePath());
         }
         return fileAsText(file).trim();
     }

--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/common/messaging/MessagesFactory.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/common/messaging/MessagesFactory.java
@@ -133,8 +133,8 @@ class MessagesFactory {
             noAttributeConstructors.put(spec, constructor);
             return true;
         } catch (NoSuchMethodException e) {
-            log.error("Error while searching for message types. Does the "
-                    +clazz.getName()+" have a constructor with "+MessageAddress.class.getName()+" as an argument?", e);
+            log.error("Error while searching for message types. Does the " + clazz.getName()
+                    + " have a constructor with " + MessageAddress.class.getName() + " as an argument?", e);
             return false;
         }
     }

--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/communicator/CommunicatorCli.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/communicator/CommunicatorCli.java
@@ -1,7 +1,5 @@
 package com.hazelcast.stabilizer.communicator;
 
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.stabilizer.Utils;
 import com.hazelcast.stabilizer.common.messaging.Message;
 import com.hazelcast.stabilizer.common.messaging.MessageAddress;
@@ -11,6 +9,7 @@ import joptsimple.OptionException;
 import joptsimple.OptionParser;
 import joptsimple.OptionSet;
 import joptsimple.OptionSpec;
+import org.apache.log4j.Logger;
 
 import java.io.IOException;
 import java.util.List;
@@ -18,7 +17,7 @@ import java.util.List;
 import static com.hazelcast.stabilizer.Utils.getFile;
 
 public class CommunicatorCli {
-    private final static ILogger log = Logger.getLogger(CommunicatorCli.class);
+    private final static Logger log = Logger.getLogger(CommunicatorCli.class);
 
     private final Communicator communicator;
 

--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/coordinator/Coordinator.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/coordinator/Coordinator.java
@@ -17,8 +17,6 @@ package com.hazelcast.stabilizer.coordinator;
 
 import com.hazelcast.config.Config;
 import com.hazelcast.config.XmlConfigBuilder;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.stabilizer.test.TestCase;
 import com.hazelcast.stabilizer.Utils;
 import com.hazelcast.stabilizer.agent.SpawnWorkerFailedException;
@@ -31,6 +29,7 @@ import com.hazelcast.stabilizer.coordinator.remoting.AgentsClient;
 import com.hazelcast.stabilizer.provisioner.Bash;
 import com.hazelcast.stabilizer.test.Failure;
 import com.hazelcast.stabilizer.test.TestSuite;
+import org.apache.log4j.Logger;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -53,7 +52,7 @@ import static java.lang.String.format;
 public class Coordinator {
 
     public final static File STABILIZER_HOME = getStablizerHome();
-    private final static ILogger log = Logger.getLogger(Coordinator.class);
+    private final static Logger log = Logger.getLogger(Coordinator.class);
 
     //options.
     public boolean monitorPerformance;
@@ -275,7 +274,7 @@ public class Coordinator {
                 echo("Skipping client startup, since no clients are configured");
             }
         } catch (SpawnWorkerFailedException e) {
-            log.severe(e.getMessage());
+            log.fatal(e.getMessage());
             System.exit(1);
         }
 
@@ -368,7 +367,7 @@ public class Coordinator {
         try {
             agentsClient.echo(msg);
         } catch (TimeoutException e) {
-            log.warning("Failed to send echo message to agents due to timeout");
+            log.warn("Failed to send echo message to agents due to timeout");
         }
         log.info(msg);
     }
@@ -442,7 +441,7 @@ public class Coordinator {
             coordinator.run();
             System.exit(0);
         } catch (Exception e) {
-            log.severe("Failed to run testsuite", e);
+            log.fatal("Failed to run testsuite", e);
             System.exit(1);
         }
     }

--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/coordinator/CoordinatorCli.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/coordinator/CoordinatorCli.java
@@ -1,7 +1,5 @@
 package com.hazelcast.stabilizer.coordinator;
 
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.stabilizer.Utils;
 import com.hazelcast.stabilizer.agent.workerjvm.WorkerJvmSettings;
 import com.hazelcast.stabilizer.test.Failure;
@@ -10,6 +8,7 @@ import joptsimple.OptionException;
 import joptsimple.OptionParser;
 import joptsimple.OptionSet;
 import joptsimple.OptionSpec;
+import org.apache.log4j.Logger;
 
 import java.io.File;
 import java.util.List;
@@ -25,7 +24,7 @@ import static java.lang.String.format;
 
 public class CoordinatorCli {
 
-    private final static ILogger log = Logger.getLogger(CoordinatorCli.class);
+    private final static Logger log = Logger.getLogger(CoordinatorCli.class);
 
     private final OptionParser parser = new OptionParser();
 

--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/coordinator/FailureMonitorThread.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/coordinator/FailureMonitorThread.java
@@ -1,8 +1,7 @@
 package com.hazelcast.stabilizer.coordinator;
 
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.stabilizer.test.Failure;
+import org.apache.log4j.Logger;
 
 import java.io.File;
 import java.util.List;
@@ -12,7 +11,7 @@ import static com.hazelcast.stabilizer.Utils.sleepSeconds;
 
 class FailureMonitorThread extends Thread {
     private final Coordinator coordinator;
-    private final ILogger log = Logger.getLogger(FailureMonitorThread.class);
+    private final Logger log = Logger.getLogger(FailureMonitorThread.class);
     private final File file;
 
     public FailureMonitorThread(Coordinator coordinator) {
@@ -34,7 +33,7 @@ class FailureMonitorThread extends Thread {
                 sleepSeconds(1);
                 scan();
             } catch (Throwable e) {
-                log.severe(e);
+                log.fatal(e);
             }
         }
     }
@@ -43,7 +42,7 @@ class FailureMonitorThread extends Thread {
         List<Failure> failures = coordinator.agentsClient.getFailures();
         for (Failure failure : failures) {
             coordinator.failureList.add(failure);
-            log.warning(buildMessage(failure));
+            log.warn(buildMessage(failure));
             appendText(failure.toString() + "\n", file);
         }
     }

--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/coordinator/PerformanceMonitor.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/coordinator/PerformanceMonitor.java
@@ -1,11 +1,10 @@
 package com.hazelcast.stabilizer.coordinator;
 
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.stabilizer.Utils;
 import com.hazelcast.stabilizer.coordinator.remoting.AgentClient;
 import com.hazelcast.stabilizer.coordinator.remoting.AgentsClient;
 import com.hazelcast.stabilizer.worker.commands.GetOperationCountCommand;
+import org.apache.log4j.Logger;
 
 import java.io.File;
 import java.util.List;
@@ -20,7 +19,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  */
 public class PerformanceMonitor {
     private static final AtomicBoolean performanceWritten = new AtomicBoolean();
-    private static final ILogger log = Logger.getLogger(PerformanceMonitor.class);
+    private static final Logger log = Logger.getLogger(PerformanceMonitor.class);
 
     private final AgentsClient client;
     private final Coordinator coordinator;
@@ -54,9 +53,9 @@ public class PerformanceMonitor {
                 try {
                     checkPerformance();
                 } catch (TimeoutException e) {
-                    log.warning("There was a timeout retrieving performance information from the members.");
+                    log.warn("There was a timeout retrieving performance information from the members.");
                 } catch (Throwable cause) {
-                    log.severe(cause);
+                    log.fatal(cause);
                 }
             }
         }

--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/coordinator/TestCaseRunner.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/coordinator/TestCaseRunner.java
@@ -1,7 +1,5 @@
 package com.hazelcast.stabilizer.coordinator;
 
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.stabilizer.test.TestCase;
 import com.hazelcast.stabilizer.Utils;
 import com.hazelcast.stabilizer.agent.workerjvm.WorkerJvmSettings;
@@ -15,6 +13,7 @@ import com.hazelcast.stabilizer.worker.commands.GetBenchmarkResultsCommand;
 import com.hazelcast.stabilizer.worker.commands.InitCommand;
 import com.hazelcast.stabilizer.worker.commands.RunCommand;
 import com.hazelcast.stabilizer.worker.commands.StopCommand;
+import org.apache.log4j.Logger;
 
 import java.io.File;
 import java.util.HashMap;
@@ -31,7 +30,7 @@ import static java.lang.String.format;
  * by having multiple TestCaseRunners  in parallel.
  */
 public class TestCaseRunner {
-    private final static ILogger log = Logger.getLogger(TestCaseRunner.class);
+    private final static Logger log = Logger.getLogger(TestCaseRunner.class);
 
     private final TestCase testCase;
     private final Coordinator coordinator;
@@ -118,7 +117,7 @@ public class TestCaseRunner {
 
             return coordinator.failureList.size() == oldFailureCount;
         } catch (Exception e) {
-            log.severe("Failed", e);
+            log.fatal("Failed", e);
             return false;
         }
     }
@@ -146,7 +145,7 @@ public class TestCaseRunner {
         try {
             agentsProbeResults = agentsClient.executeOnAllWorkers(new GetBenchmarkResultsCommand(testCase.id));
         } catch (TimeoutException e) {
-            log.severe("A timeout happened while retrieving the benchmark results");
+            log.fatal("A timeout happened while retrieving the benchmark results");
             return combinedResults;
         }
         for (List<Map<String, R>> agentProbeResults : agentsProbeResults) {
@@ -160,7 +159,7 @@ public class TestCaseRunner {
                             combinedValue = currentResult.combine(combinedValue);
                             combinedResults.put(probeName, combinedValue);
                         } else {
-                            log.warning("Probe " + probeName + " has null value for some member. This should not happen.");
+                            log.warn("Probe " + probeName + " has null value for some member. This should not happen.");
                         }
                     }
                 }
@@ -232,7 +231,7 @@ public class TestCaseRunner {
         try {
             agentsClient.echo(prefix + msg);
         } catch (TimeoutException e) {
-            log.warning("Failed to echo message due to timeout");
+            log.warn("Failed to echo message due to timeout");
         }
         log.info(prefix + msg);
     }

--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/coordinator/remoting/AgentClient.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/coordinator/remoting/AgentClient.java
@@ -1,10 +1,9 @@
 package com.hazelcast.stabilizer.coordinator.remoting;
 
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.stabilizer.Utils;
 import com.hazelcast.stabilizer.agent.remoting.AgentRemoteService;
 import com.hazelcast.stabilizer.common.AgentAddress;
+import org.apache.log4j.Logger;
 
 import java.io.IOException;
 import java.io.ObjectInputStream;
@@ -18,7 +17,7 @@ import static com.hazelcast.stabilizer.Utils.sleepSeconds;
 
 public class AgentClient {
 
-    private final static ILogger log = Logger.getLogger(AgentClient.class);
+    private final static Logger log = Logger.getLogger(AgentClient.class);
 
     final String publicAddress;
     final String privateIp;
@@ -72,9 +71,9 @@ public class AgentClient {
             } catch (ConnectException e) {
                 if (k < 10) {
                     // it can happen that when a machine is under a lot of pressure, the connection can't be established
-                    log.finest("Failed to connect to public address: " + publicAddress + " sleeping for 1 second and trying again");
+                    log.debug("Failed to connect to public address: " + publicAddress + " sleeping for 1 second and trying again");
                 } else {
-                    log.warning("Failed to connect to public address: " + publicAddress + " sleeping for 1 second and trying again");
+                    log.warn("Failed to connect to public address: " + publicAddress + " sleeping for 1 second and trying again");
                 }
                 sleepSeconds(1);
                 connectException = e;

--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/provisioner/Bash.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/provisioner/Bash.java
@@ -1,8 +1,5 @@
 package com.hazelcast.stabilizer.provisioner;
 
-
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.stabilizer.NativeUtils;
 import com.hazelcast.stabilizer.common.StabilizerProperties;
 
@@ -12,8 +9,6 @@ import static com.hazelcast.stabilizer.Utils.getVersion;
 import static java.lang.String.format;
 
 public class Bash {
-    private final static ILogger log = Logger.getLogger(Bash.class);
-
     private final String sshOptions;
     private final String user;
 

--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/provisioner/CloudInfo.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/provisioner/CloudInfo.java
@@ -1,8 +1,7 @@
 package com.hazelcast.stabilizer.provisioner;
 
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.stabilizer.common.StabilizerProperties;
+import org.apache.log4j.Logger;
 import org.jclouds.compute.ComputeService;
 import org.jclouds.compute.domain.Hardware;
 import org.jclouds.compute.domain.Image;
@@ -18,7 +17,7 @@ import static java.lang.String.format;
  * Commandline tool to retrieve various cloud info.
  */
 public class CloudInfo {
-    private final static ILogger log = Logger.getLogger(CloudInfo.class);
+    private final static Logger log = Logger.getLogger(CloudInfo.class);
 
     public StabilizerProperties props = new StabilizerProperties();
 
@@ -107,7 +106,7 @@ public class CloudInfo {
             cli.run(args);
             System.exit(0);
         } catch (Throwable e) {
-            log.severe(e);
+            log.fatal(e);
             System.exit(1);
         }
     }

--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/provisioner/CloudInfoCli.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/provisioner/CloudInfoCli.java
@@ -1,17 +1,17 @@
 package com.hazelcast.stabilizer.provisioner;
 
-import com.hazelcast.logging.ILogger;
 import com.hazelcast.stabilizer.Utils;
 import joptsimple.OptionException;
 import joptsimple.OptionParser;
 import joptsimple.OptionSet;
 import joptsimple.OptionSpec;
+import org.apache.log4j.Logger;
 
 import java.io.File;
 
 public class CloudInfoCli {
 
-    private final static ILogger log = com.hazelcast.logging.Logger.getLogger(ProvisionerCli.class);
+    private final static Logger log = Logger.getLogger(ProvisionerCli.class);
 
     public final OptionParser parser = new OptionParser();
 

--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/provisioner/ComputeServiceBuilder.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/provisioner/ComputeServiceBuilder.java
@@ -1,10 +1,9 @@
 package com.hazelcast.stabilizer.provisioner;
 
 import com.google.inject.AbstractModule;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.stabilizer.Utils;
 import com.hazelcast.stabilizer.common.StabilizerProperties;
+import org.apache.log4j.Logger;
 import org.jclouds.ContextBuilder;
 import org.jclouds.compute.ComputeService;
 import org.jclouds.compute.ComputeServiceContext;
@@ -16,16 +15,14 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Properties;
 
-import static com.hazelcast.stabilizer.Utils.fileAsText;
 import static com.hazelcast.stabilizer.Utils.newFile;
-import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static org.jclouds.compute.config.ComputeServiceProperties.POLL_INITIAL_PERIOD;
 import static org.jclouds.compute.config.ComputeServiceProperties.POLL_MAX_PERIOD;
 
 public class ComputeServiceBuilder {
 
-    private final static ILogger log = Logger.getLogger(ComputeServiceBuilder.class);
+    private final static Logger log = Logger.getLogger(ComputeServiceBuilder.class);
 
     private final StabilizerProperties props;
 
@@ -43,8 +40,8 @@ public class ComputeServiceBuilder {
         String identity = props.get("CLOUD_IDENTITY");
         String credential = props.get("CLOUD_CREDENTIAL");
 
-        if (log.isFinestEnabled()) {
-            log.finest("Using CLOUD_PROVIDER: " + cloudProvider);
+        if (log.isDebugEnabled()) {
+            log.debug("Using CLOUD_PROVIDER: " + cloudProvider);
         }
 
         ContextBuilder contextBuilder = newContextBuilder(cloudProvider);

--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/provisioner/HazelcastJars.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/provisioner/HazelcastJars.java
@@ -1,9 +1,8 @@
 package com.hazelcast.stabilizer.provisioner;
 
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.stabilizer.Utils;
 import com.hazelcast.stabilizer.provisioner.git.GitSupport;
+import org.apache.log4j.Logger;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -22,7 +21,7 @@ public class HazelcastJars {
     public static final String GIT_VERSION_PREFIX = "git=";
     public static final String MAVEN_VERSION_PREFIX = "maven=";
 
-    private final static ILogger log = Logger.getLogger(HazelcastJars.class);
+    private final static Logger log = Logger.getLogger(HazelcastJars.class);
     private final Bash bash;
     private final GitSupport gitSupport;
     private final String versionSpec;
@@ -66,7 +65,7 @@ public class HazelcastJars {
             String revision = versionSpec.substring(GIT_VERSION_PREFIX.length());
             gitRetrieve(revision);
         } else {
-            log.severe("Unrecognized version spec:" + versionSpec);
+            log.fatal("Unrecognized version spec:" + versionSpec);
             System.exit(1);
         }
     }
@@ -93,20 +92,20 @@ public class HazelcastJars {
             if (version.endsWith("-SNAPSHOT")) {
                 String baseUrl = "https://oss.sonatype.org/content/repositories/snapshots";
                 String mavenMetadataUrl = format("%s/com/hazelcast/%s/%s/maven-metadata.xml", baseUrl, artifact, version);
-                log.finest("Loading: " + mavenMetadataUrl);
+                log.debug("Loading: " + mavenMetadataUrl);
                 String mavenMetadata = null;
                 try {
                     mavenMetadata = Utils.getText(mavenMetadataUrl);
                 } catch (FileNotFoundException e) {
-                    log.severe("Failed to load " + artifact + "-" + version + ", because :"
+                    log.fatal("Failed to load " + artifact + "-" + version + ", because :"
                             + mavenMetadataUrl + " was not found");
                     System.exit(1);
                 } catch (IOException e) {
-                    log.severe("Could not load:" + mavenMetadataUrl);
+                    log.fatal("Could not load:" + mavenMetadataUrl);
                     System.exit(1);
                 }
 
-                log.finest(mavenMetadata);
+                log.debug(mavenMetadata);
                 String timestamp = getTagValue(mavenMetadata, "timestamp");
                 String buildnumber = getTagValue(mavenMetadata, "buildNumber");
                 String shortVersion = version.replace("-SNAPSHOT", "");

--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/provisioner/Provisioner.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/provisioner/Provisioner.java
@@ -1,8 +1,6 @@
 package com.hazelcast.stabilizer.provisioner;
 
 import com.google.common.base.Predicate;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.stabilizer.Utils;
 import com.hazelcast.stabilizer.common.AgentAddress;
 import com.hazelcast.stabilizer.common.AgentsFile;
@@ -11,6 +9,7 @@ import com.hazelcast.stabilizer.common.StabilizerProperties;
 import com.hazelcast.stabilizer.provisioner.git.BuildSupport;
 import com.hazelcast.stabilizer.provisioner.git.GitSupport;
 import com.hazelcast.stabilizer.provisioner.git.HazelcastJARFinder;
+import org.apache.log4j.Logger;
 import org.jclouds.compute.ComputeService;
 import org.jclouds.compute.domain.NodeMetadata;
 import org.jclouds.compute.domain.Template;
@@ -40,7 +39,7 @@ import static java.lang.String.format;
 //https://github.com/jclouds/jclouds-examples/blob/master/compute-basics/src/main/java/org/jclouds/examples/compute/basics/MainApp.java
 //https://github.com/jclouds/jclouds-examples/blob/master/minecraft-compute/src/main/java/org/jclouds/examples/minecraft/NodeManager.java
 public class Provisioner {
-    private final static ILogger log = Logger.getLogger(Provisioner.class);
+    private final static Logger log = Logger.getLogger(Provisioner.class);
 
     public final StabilizerProperties props = new StabilizerProperties();
 
@@ -252,7 +251,7 @@ public class Provisioner {
             try {
                 f.get();
             } catch (ExecutionException e) {
-                log.severe("Failed provision", e);
+                log.fatal("Failed provision", e);
                 System.exit(1);
             }
         }
@@ -432,7 +431,7 @@ public class Provisioner {
             cli.run(args);
             System.exit(0);
         } catch (Throwable e) {
-            log.severe(e);
+            log.fatal(e);
             System.exit(1);
         }
     }

--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/provisioner/ProvisionerCli.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/provisioner/ProvisionerCli.java
@@ -1,16 +1,16 @@
 package com.hazelcast.stabilizer.provisioner;
 
-import com.hazelcast.logging.ILogger;
 import com.hazelcast.stabilizer.Utils;
 import joptsimple.OptionException;
 import joptsimple.OptionParser;
 import joptsimple.OptionSet;
 import joptsimple.OptionSpec;
+import org.apache.log4j.Logger;
 
 import java.io.File;
 
 public class ProvisionerCli {
-    private final static ILogger log = com.hazelcast.logging.Logger.getLogger(ProvisionerCli.class);
+    private final static Logger log = Logger.getLogger(ProvisionerCli.class);
 
     public final OptionParser parser = new OptionParser();
 

--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/provisioner/TemplateBuilder.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/provisioner/TemplateBuilder.java
@@ -1,11 +1,10 @@
 package com.hazelcast.stabilizer.provisioner;
 
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.stabilizer.Utils;
 import com.hazelcast.stabilizer.agent.remoting.AgentRemoteService;
 import com.hazelcast.stabilizer.agent.workerjvm.WorkerJvmManager;
 import com.hazelcast.stabilizer.common.StabilizerProperties;
+import org.apache.log4j.Logger;
 import org.jclouds.aws.ec2.AWSEC2Api;
 import org.jclouds.aws.ec2.compute.AWSEC2TemplateOptions;
 import org.jclouds.compute.ComputeService;
@@ -21,7 +20,7 @@ import java.util.List;
 import java.util.Set;
 
 public class TemplateBuilder {
-    private final static ILogger log = Logger.getLogger(Provisioner.class);
+    private final static Logger log = Logger.getLogger(Provisioner.class);
 
     private final ComputeService compute;
     private final StabilizerProperties props;
@@ -79,7 +78,7 @@ public class TemplateBuilder {
                     .from(spec)
                     .build();
         } catch (IllegalArgumentException e) {
-            log.finest(e);
+            log.debug(e);
             Utils.exitWithError(log, e.getMessage());
             return null;
         }

--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/provisioner/git/BuildSupport.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/provisioner/git/BuildSupport.java
@@ -1,9 +1,8 @@
 package com.hazelcast.stabilizer.provisioner.git;
 
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.stabilizer.Utils;
 import com.hazelcast.stabilizer.provisioner.Bash;
+import org.apache.log4j.Logger;
 
 import java.io.File;
 
@@ -11,7 +10,7 @@ import static com.hazelcast.stabilizer.Utils.exitWithError;
 import static java.lang.String.format;
 
 public class BuildSupport {
-    private final static ILogger log = Logger.getLogger(BuildSupport.class);
+    private final static Logger log = Logger.getLogger(BuildSupport.class);
 
     private final Bash bash;
     private final HazelcastJARFinder jarFinder;

--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/provisioner/git/GitSupport.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/provisioner/git/GitSupport.java
@@ -1,8 +1,7 @@
 package com.hazelcast.stabilizer.provisioner.git;
 
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.stabilizer.Utils;
+import org.apache.log4j.Logger;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.ResetCommand;
 import org.eclipse.jgit.api.errors.GitAPIException;
@@ -23,7 +22,7 @@ import static com.hazelcast.stabilizer.Utils.exitWithError;
 
 public class GitSupport {
     private static final String HAZELCAST_MAIN_REPO_URL = "https://github.com/hazelcast/hazelcast.git";
-    private final static ILogger log = Logger.getLogger(GitSupport.class);
+    private final static Logger log = Logger.getLogger(GitSupport.class);
     public static final String CUSTOM_REPOSITORY_PREFIX = "custom";
 
     private final BuildSupport buildSupport;

--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/provisioner/git/HazelcastJARFinder.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/provisioner/git/HazelcastJARFinder.java
@@ -1,14 +1,14 @@
 package com.hazelcast.stabilizer.provisioner.git;
 
-import com.hazelcast.logging.ILogger;
 import com.hazelcast.stabilizer.Utils;
+import org.apache.log4j.Logger;
 
 import java.io.File;
 
 import static com.hazelcast.stabilizer.Utils.exitWithError;
 
 public class HazelcastJARFinder {
-    private final static ILogger log = com.hazelcast.logging.Logger.getLogger(HazelcastJARFinder.class);
+    private final static Logger log = Logger.getLogger(HazelcastJARFinder.class);
 
     public File[] find(File path) {
         File memberPath = Utils.newFile(path, "hazelcast", "target");

--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/test/TestRunner.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/test/TestRunner.java
@@ -19,11 +19,10 @@ import com.hazelcast.config.Config;
 import com.hazelcast.config.XmlConfigBuilder;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.stabilizer.Utils;
 import com.hazelcast.stabilizer.probes.probes.ProbesConfiguration;
 import com.hazelcast.stabilizer.worker.TestContainer;
+import org.apache.log4j.Logger;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -40,7 +39,7 @@ import static java.lang.String.format;
  */
 public class TestRunner<E> {
 
-    private final static ILogger log = Logger.getLogger(TestRunner.class);
+    private final static Logger log = Logger.getLogger(TestRunner.class);
     private final E test;
     private final TestContainer testInvoker;
 

--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/test/utils/ExceptionReporter.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/test/utils/ExceptionReporter.java
@@ -1,7 +1,6 @@
 package com.hazelcast.stabilizer.test.utils;
 
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
+import org.apache.log4j.Logger;
 
 import java.io.File;
 import java.io.IOException;
@@ -18,7 +17,7 @@ public class ExceptionReporter {
     public static final int MAX_EXCEPTION_COUNT = 1000;
 
     private final static AtomicLong FAILURE_ID = new AtomicLong(0);
-    private final static ILogger log = Logger.getLogger(ExceptionReporter.class);
+    private final static Logger log = Logger.getLogger(ExceptionReporter.class);
 
     /**
      * Writes the cause to file.
@@ -29,19 +28,19 @@ public class ExceptionReporter {
      */
     public static void report(String testId, Throwable cause) {
         if (cause == null) {
-            log.severe("Can't call report with a null exception");
+            log.fatal("Can't call report with a null exception");
             return;
         }
 
         long exceptionCount = FAILURE_ID.incrementAndGet();
 
         if (exceptionCount > MAX_EXCEPTION_COUNT) {
-            log.warning("Exception #" + exceptionCount + " detected. The maximum number of exceptions has been" +
+            log.warn("Exception #" + exceptionCount + " detected. The maximum number of exceptions has been" +
                     "exceeded, so it won't be reported to the agent.", cause);
             return;
         }
 
-        log.warning("Exception #" + exceptionCount + " detected", cause);
+        log.warn("Exception #" + exceptionCount + " detected", cause);
 
         String targetFileName = exceptionCount + ".exception";
 
@@ -53,7 +52,7 @@ public class ExceptionReporter {
                 throw new IOException("Could not create tmp file:" + tmpFile.getAbsolutePath() + " file already exists.");
             }
         } catch (IOException e) {
-            log.severe("Could not report exception; this means that this exception is not visible to the coordinator", e);
+            log.fatal("Could not report exception; this means that this exception is not visible to the coordinator", e);
             return;
         }
 
@@ -62,7 +61,7 @@ public class ExceptionReporter {
         final File file = new File(targetFileName);
 
         if (!tmpFile.renameTo(file)) {
-            log.severe("Failed to rename tmp file:" + tmpFile + " to " + file);
+            log.fatal("Failed to rename tmp file:" + tmpFile + " to " + file);
         }
     }
 

--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/worker/PerformanceMonitor.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/worker/PerformanceMonitor.java
@@ -1,9 +1,8 @@
 package com.hazelcast.stabilizer.worker;
 
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.stabilizer.Utils;
 import com.hazelcast.stabilizer.test.TestContext;
+import org.apache.log4j.Logger;
 
 import java.io.File;
 import java.text.SimpleDateFormat;
@@ -14,7 +13,7 @@ import java.util.HashMap;
 import static java.lang.String.format;
 
 class PerformanceMonitor extends Thread {
-    private static final ILogger log = Logger.getLogger(PerformanceMonitor.class);
+    private static final Logger log = Logger.getLogger(PerformanceMonitor.class);
 
     private final File globalPerformanceFile = new File("performance.txt");
     private final SimpleDateFormat simpleDateFormat = new SimpleDateFormat("dd/MM/yyyy HH:mm:ss");
@@ -41,7 +40,7 @@ class PerformanceMonitor extends Thread {
                 Thread.sleep(5000);
                 writeStatsToFiles();
             } catch (Throwable t) {
-                log.severe("Failed to run performance monitor", t);
+                log.fatal("Failed to run performance monitor", t);
             }
         }
     }

--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/worker/TestContainer.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/worker/TestContainer.java
@@ -1,7 +1,5 @@
 package com.hazelcast.stabilizer.worker;
 
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.stabilizer.common.messaging.Message;
 import com.hazelcast.stabilizer.probes.probes.IntervalProbe;
 import com.hazelcast.stabilizer.probes.probes.ProbesConfiguration;
@@ -41,8 +39,6 @@ import static java.lang.String.format;
  * @param <T>
  */
 public class TestContainer<T extends TestContext> {
-
-    private final static ILogger log = Logger.getLogger(TestContainer.class);
 
     private final Object testObject;
     private final Class<? extends Object> clazz;

--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/worker/WorkerMessageProcessor.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/worker/WorkerMessageProcessor.java
@@ -3,11 +3,10 @@ package com.hazelcast.stabilizer.worker;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.HazelcastInstanceAware;
 import com.hazelcast.core.Member;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.stabilizer.common.messaging.Message;
 import com.hazelcast.stabilizer.common.messaging.MessageAddress;
 import com.hazelcast.stabilizer.test.TestContext;
+import org.apache.log4j.Logger;
 
 import java.util.Iterator;
 import java.util.Random;
@@ -20,7 +19,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 public class WorkerMessageProcessor {
-    private static final ILogger log = Logger.getLogger(WorkerMessageProcessor.class);
+    private static final Logger log = Logger.getLogger(WorkerMessageProcessor.class);
     private static final int TIMEOUT = 60;
 
     private final ConcurrentMap<String, TestContainer<TestContext>> tests;
@@ -63,7 +62,7 @@ public class WorkerMessageProcessor {
             try {
                 processTestMessage(message);
             } catch (Throwable throwable) {
-                log.severe("Error while processing message", throwable);
+                log.fatal("Error while processing message", throwable);
             }
         }
     }
@@ -110,8 +109,8 @@ public class WorkerMessageProcessor {
             } else if (hazelcastClientInstance != null) {
                 ((HazelcastInstanceAware) message).setHazelcastInstance(hazelcastClientInstance);
             } else {
-                log.warning("Message "+message.getClass().getName()+" implements "
-                        +HazelcastInstanceAware.class+" interface, but no instance is currently running in this worker.");
+                log.warn("Message " + message.getClass().getName() + " implements " + HazelcastInstanceAware.class
+                        + " interface, but no instance is currently running in this worker.");
             }
         }
     }
@@ -125,7 +124,7 @@ public class WorkerMessageProcessor {
         } else if (MessageAddress.RANDOM.equals(testAddress)) {
             TestContainer<?> randomTestContainer = getRandomTestContainerOrNull();
             if (randomTestContainer == null) {
-                log.warning("No test container is known to this worker. Is it a race-condition?");
+                log.warn("No test container is known to this worker. Is it a race-condition?");
             } else {
                 randomTestContainer.sendMessage(message);
             }

--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/concurrent/atomiclong/AsyncAtomicLongTest.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/concurrent/atomiclong/AsyncAtomicLongTest.java
@@ -34,7 +34,6 @@ import com.hazelcast.stabilizer.tests.helpers.KeyLocality;
 import com.hazelcast.stabilizer.tests.helpers.KeyUtils;
 import com.hazelcast.stabilizer.test.utils.AssertTask;
 import com.hazelcast.stabilizer.test.utils.ExceptionReporter;
-import com.hazelcast.stabilizer.test.utils.TestUtils;
 import com.hazelcast.stabilizer.test.utils.ThreadSpawner;
 
 import java.util.LinkedList;
@@ -44,6 +43,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static com.hazelcast.stabilizer.test.utils.TestUtils.assertTrueEventually;
+import static com.hazelcast.stabilizer.tests.helpers.HazelcastTestUtils.getOperationCountInformation;
 import static org.junit.Assert.assertEquals;
 
 public class AsyncAtomicLongTest {
@@ -94,7 +94,7 @@ public class AsyncAtomicLongTest {
             counter.destroy();
         }
         totalCounter.destroy();
-        log.info(TestUtils.getOperationCountInformation(targetInstance));
+        log.info(getOperationCountInformation(targetInstance));
     }
 
     @Run

--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/concurrent/atomiclong/AtomicLongTest.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/concurrent/atomiclong/AtomicLongTest.java
@@ -28,12 +28,12 @@ import com.hazelcast.stabilizer.test.annotations.Teardown;
 import com.hazelcast.stabilizer.test.annotations.Verify;
 import com.hazelcast.stabilizer.tests.helpers.KeyLocality;
 import com.hazelcast.stabilizer.tests.helpers.KeyUtils;
-import com.hazelcast.stabilizer.test.utils.TestUtils;
 import com.hazelcast.stabilizer.test.utils.ThreadSpawner;
 
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicLong;
 
+import static com.hazelcast.stabilizer.tests.helpers.HazelcastTestUtils.getOperationCountInformation;
 import static org.junit.Assert.assertEquals;
 
 public class AtomicLongTest {
@@ -83,7 +83,7 @@ public class AtomicLongTest {
             counter.destroy();
         }
         totalCounter.destroy();
-        log.info(TestUtils.getOperationCountInformation(targetInstance));
+        log.info(getOperationCountInformation(targetInstance));
     }
 
     @Run

--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/concurrent/atomicreference/AtomicReferenceTest.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/concurrent/atomicreference/AtomicReferenceTest.java
@@ -27,7 +27,6 @@ import com.hazelcast.stabilizer.test.annotations.Setup;
 import com.hazelcast.stabilizer.test.annotations.Teardown;
 import com.hazelcast.stabilizer.tests.helpers.KeyLocality;
 import com.hazelcast.stabilizer.tests.helpers.KeyUtils;
-import com.hazelcast.stabilizer.test.utils.TestUtils;
 import com.hazelcast.stabilizer.test.utils.ThreadSpawner;
 import com.hazelcast.stabilizer.tests.helpers.StringUtils;
 
@@ -35,6 +34,7 @@ import java.util.Random;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static com.hazelcast.stabilizer.test.utils.TestUtils.randomByteArray;
+import static com.hazelcast.stabilizer.tests.helpers.HazelcastTestUtils.getOperationCountInformation;
 
 public class AtomicReferenceTest {
 
@@ -96,7 +96,7 @@ public class AtomicReferenceTest {
         for (IAtomicReference counter : counters) {
             counter.destroy();
         }
-        log.info(TestUtils.getOperationCountInformation(targetInstance));
+        log.info(getOperationCountInformation(targetInstance));
     }
 
     @Run

--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/helpers/HazelcastTestUtils.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/helpers/HazelcastTestUtils.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2008-2013, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hazelcast.stabilizer.tests.helpers;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.HazelcastInstanceAware;
+import com.hazelcast.core.IExecutorService;
+import com.hazelcast.core.Member;
+import com.hazelcast.core.Partition;
+import com.hazelcast.core.PartitionService;
+import com.hazelcast.instance.HazelcastInstanceImpl;
+import com.hazelcast.instance.HazelcastInstanceProxy;
+import com.hazelcast.instance.Node;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+import com.hazelcast.spi.OperationService;
+import com.hazelcast.stabilizer.test.utils.PropertyBindingSupport;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+public class HazelcastTestUtils {
+
+    private static final ILogger log = Logger.getLogger(HazelcastTestUtils.class);
+
+    // we don't want instances
+    private HazelcastTestUtils() {
+    }
+
+    public static String getPartitionDistributionInformation(HazelcastInstance hz) {
+        Map<Member, Integer> partitionCountMap = new HashMap<Member, Integer>();
+        int totalPartitions = 0;
+        for(Partition partition: hz.getPartitionService().getPartitions()){
+            totalPartitions++;
+            Member member = partition.getOwner();
+            Integer count = partitionCountMap.get(member);
+            if(count == null){
+                count = 0;
+            }
+
+            count++;
+            partitionCountMap.put(member,count);
+        }
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("total partitions:").append(totalPartitions).append("\n");
+        for (Map.Entry<Member, Integer> entry : partitionCountMap.entrySet()) {
+            Member member = entry.getKey();
+            long count = entry.getValue();
+            double percentage = count * 100d / totalPartitions;
+            sb.append(member).append(" total=").append(count).append(" percentage=").append(percentage).append("%\n");
+        }
+        return sb.toString();
+    }
+
+    public static String getOperationCountInformation(HazelcastInstance hz) {
+        Map<Member, Long> operationCountMap = getOperationCount(hz);
+
+        long total = 0;
+        for (Long count : operationCountMap.values()) {
+            total += count;
+        }
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("total operations:").append(total).append("\n");
+        for (Map.Entry<Member, Long> entry : operationCountMap.entrySet()) {
+            Member member = entry.getKey();
+            long count = entry.getValue();
+            double percentage = count * 100d / total;
+            sb.append(member).append(" total=").append(count).append(" percentage=").append(percentage).append("%\n");
+        }
+        return sb.toString();
+    }
+
+    public static Map<Member, Long> getOperationCount(HazelcastInstance hz) {
+        IExecutorService executorService = hz.getExecutorService("operationCountExecutor");
+
+        Map<Member, Future<Long>> futures = new HashMap<Member, Future<Long>>();
+        for (Member member : hz.getCluster().getMembers()) {
+            Future<Long> future = executorService.submitToMember(new GetOperationCount(), member);
+            futures.put(member, future);
+        }
+
+        Map<Member, Long> result = new HashMap<Member, Long>();
+        for (Map.Entry<Member, Future<Long>> entry : futures.entrySet()) {
+            try {
+                Member member = entry.getKey();
+                Long value = entry.getValue().get();
+                if(value == null){
+                    value = 0l;
+                }
+                result.put(member, value);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            } catch (ExecutionException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        return result;
+    }
+
+    public final static class GetOperationCount implements Callable<Long>, HazelcastInstanceAware, Serializable {
+        private transient HazelcastInstance hz;
+
+        @Override
+        public Long call() throws Exception {
+            try {
+                Node node = getNode(hz);
+                OperationService operationService = node.getNodeEngine().getOperationService();
+                return operationService.getExecutedOperationCount();
+            } catch (NoSuchMethodError e) {
+                log.warning(e);
+                return -1l;
+            }
+        }
+
+        @Override
+        public void setHazelcastInstance(HazelcastInstance hazelcastInstance) {
+            this.hz = hazelcastInstance;
+        }
+    }
+
+    public static void waitClusterSize(ILogger logger, HazelcastInstance hz, int clusterSize) throws InterruptedException {
+        for (; ; ) {
+            if (hz.getCluster().getMembers().size() >= clusterSize) {
+                return;
+            }
+
+            logger.info("waiting cluster == " + clusterSize);
+            Thread.sleep(1000);
+        }
+    }
+
+    public static Node getNode(HazelcastInstance hz) {
+        HazelcastInstanceImpl impl = getHazelcastInstanceImpl(hz);
+        return impl != null ? impl.node : null;
+    }
+
+    public static HazelcastInstanceImpl getHazelcastInstanceImpl(HazelcastInstance hz) {
+        HazelcastInstanceImpl impl = null;
+        if (hz instanceof HazelcastInstanceProxy) {
+            return PropertyBindingSupport.getField(hz, "original");
+        } else if (hz instanceof HazelcastInstanceImpl) {
+            impl = (HazelcastInstanceImpl) hz;
+        }
+        return impl;
+    }
+
+    public static long nextKeyOwnedBy(long key, HazelcastInstance instance) {
+        final Member localMember = instance.getCluster().getLocalMember();
+        final PartitionService partitionService = instance.getPartitionService();
+        for (; ; ) {
+            Partition partition = partitionService.getPartition(key);
+            if (localMember.equals(partition.getOwner())) {
+                return key;
+            }
+            key++;
+        }
+    }
+
+    public static boolean isMemberNode(HazelcastInstance instance) {
+        return instance instanceof HazelcastInstanceProxy;
+    }
+
+    public static boolean isClient(HazelcastInstance instance) {
+        return !isMemberNode(instance);
+    }
+}

--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/helpers/KeyUtils.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/helpers/KeyUtils.java
@@ -8,7 +8,7 @@ import com.hazelcast.core.PartitionService;
 import java.util.Random;
 
 import static com.hazelcast.stabilizer.Utils.sleepSeconds;
-import static com.hazelcast.stabilizer.test.utils.TestUtils.isClient;
+import static com.hazelcast.stabilizer.tests.helpers.HazelcastTestUtils.isClient;
 
 public class KeyUtils {
 

--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/icache/AddRemoveListenerICacheTest.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/icache/AddRemoveListenerICacheTest.java
@@ -17,7 +17,6 @@ import com.hazelcast.stabilizer.test.annotations.Verify;
 import com.hazelcast.stabilizer.test.annotations.Warmup;
 import com.hazelcast.stabilizer.tests.icache.helpers.MyCacheEntryEventFilter;
 import com.hazelcast.stabilizer.tests.icache.helpers.MyCacheEntryListener;
-import com.hazelcast.stabilizer.test.utils.TestUtils;
 import com.hazelcast.stabilizer.test.utils.ThreadSpawner;
 
 import javax.cache.Cache;
@@ -25,6 +24,8 @@ import javax.cache.configuration.FactoryBuilder;
 import javax.cache.configuration.MutableCacheEntryListenerConfiguration;
 import java.io.Serializable;
 import java.util.Random;
+
+import static com.hazelcast.stabilizer.tests.helpers.HazelcastTestUtils.isMemberNode;
 
 /**
  * In This test we concurrently add remove cache listeners while putting and getting from the cache
@@ -63,7 +64,7 @@ public class AddRemoveListenerICacheTest {
         targetInstance = testContext.getTargetInstance();
         basename = testContext.getTestId();
 
-        if (TestUtils.isMemberNode(targetInstance)) {
+        if (isMemberNode(targetInstance)) {
             HazelcastServerCachingProvider hcp = new HazelcastServerCachingProvider();
             cacheManager = new HazelcastServerCacheManager(hcp, targetInstance, hcp.getDefaultURI(), hcp.getDefaultClassLoader(), null);
         } else {

--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/icache/BatchingICacheTest.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/icache/BatchingICacheTest.java
@@ -20,7 +20,6 @@ import com.hazelcast.stabilizer.test.annotations.Run;
 import com.hazelcast.stabilizer.test.annotations.Setup;
 import com.hazelcast.stabilizer.test.annotations.Teardown;
 import com.hazelcast.stabilizer.test.annotations.Warmup;
-import com.hazelcast.stabilizer.test.utils.TestUtils;
 import com.hazelcast.stabilizer.test.utils.ThreadSpawner;
 import com.hazelcast.stabilizer.worker.OperationSelector;
 
@@ -29,6 +28,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicLong;
+
+import static com.hazelcast.stabilizer.tests.helpers.HazelcastTestUtils.isMemberNode;
 
 /**
  * This test demonstrates effect of batching. It uses async methods to invoke operation and wait for future
@@ -63,7 +64,7 @@ public class BatchingICacheTest {
 
         targetInstance = testContext.getTargetInstance();
         CacheManager cacheManager;
-        if (TestUtils.isMemberNode(targetInstance)) {
+        if (isMemberNode(targetInstance)) {
             HazelcastServerCachingProvider hcp = new HazelcastServerCachingProvider();
             cacheManager = new HazelcastServerCacheManager(
                     hcp, targetInstance, hcp.getDefaultURI(), hcp.getDefaultClassLoader(), null);

--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/icache/CacheLoaderTest.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/icache/CacheLoaderTest.java
@@ -30,7 +30,6 @@ import com.hazelcast.stabilizer.test.annotations.Run;
 import com.hazelcast.stabilizer.test.annotations.Setup;
 import com.hazelcast.stabilizer.test.annotations.Verify;
 import com.hazelcast.stabilizer.test.annotations.Warmup;
-import com.hazelcast.stabilizer.test.utils.TestUtils;
 import com.hazelcast.stabilizer.test.utils.ThreadSpawner;
 
 import javax.cache.Cache;
@@ -41,6 +40,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
+import static com.hazelcast.stabilizer.tests.helpers.HazelcastTestUtils.isMemberNode;
 import static junit.framework.Assert.assertTrue;
 
 /**
@@ -75,7 +75,7 @@ public class CacheLoaderTest {
         targetInstance = testContext.getTargetInstance();
         basename = testContext.getTestId();
 
-        if (TestUtils.isMemberNode(targetInstance)) {
+        if (isMemberNode(targetInstance)) {
             HazelcastServerCachingProvider hcp = new HazelcastServerCachingProvider();
             cacheManager = new HazelcastServerCacheManager(hcp, targetInstance, hcp.getDefaultURI(), hcp.getDefaultClassLoader(), null);
         } else {

--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/icache/CasICacheTest.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/icache/CasICacheTest.java
@@ -19,13 +19,13 @@ import com.hazelcast.stabilizer.test.annotations.Setup;
 import com.hazelcast.stabilizer.test.annotations.Teardown;
 import com.hazelcast.stabilizer.test.annotations.Verify;
 import com.hazelcast.stabilizer.test.annotations.Warmup;
-import com.hazelcast.stabilizer.test.utils.TestUtils;
 import com.hazelcast.stabilizer.test.utils.ThreadSpawner;
 
 import javax.cache.CacheException;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicLong;
 
+import static com.hazelcast.stabilizer.tests.helpers.HazelcastTestUtils.isMemberNode;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -63,7 +63,7 @@ public class CasICacheTest {
         resultsPerWorker = targetInstance.getList(basename);
 
 
-        if (TestUtils.isMemberNode(targetInstance)) {
+        if (isMemberNode(targetInstance)) {
             HazelcastServerCachingProvider hcp = new HazelcastServerCachingProvider();
             cacheManager = new HazelcastServerCacheManager(
                     hcp, targetInstance, hcp.getDefaultURI(), hcp.getDefaultClassLoader(), null);

--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/icache/ConcurentCreateICacheTest.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/icache/ConcurentCreateICacheTest.java
@@ -29,11 +29,11 @@ import com.hazelcast.stabilizer.test.TestContext;
 import com.hazelcast.stabilizer.test.annotations.Run;
 import com.hazelcast.stabilizer.test.annotations.Setup;
 import com.hazelcast.stabilizer.test.annotations.Verify;
-import com.hazelcast.stabilizer.test.utils.TestUtils;
 
 import javax.cache.CacheException;
 import java.io.Serializable;
 
+import static com.hazelcast.stabilizer.tests.helpers.HazelcastTestUtils.isMemberNode;
 import static junit.framework.Assert.assertEquals;
 
 /**
@@ -56,7 +56,7 @@ public class ConcurentCreateICacheTest {
         targetInstance = testContext.getTargetInstance();
         baseName = testContext.getTestId();
 
-        if (TestUtils.isMemberNode(targetInstance)) {
+        if (isMemberNode(targetInstance)) {
             HazelcastServerCachingProvider hcp = new HazelcastServerCachingProvider();
             cacheManager = new HazelcastServerCacheManager(
                     hcp, targetInstance, hcp.getDefaultURI(), hcp.getDefaultClassLoader(), null);

--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/icache/CreateDestroyICacheTest.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/icache/CreateDestroyICacheTest.java
@@ -30,12 +30,13 @@ import com.hazelcast.stabilizer.test.TestContext;
 import com.hazelcast.stabilizer.test.annotations.Run;
 import com.hazelcast.stabilizer.test.annotations.Setup;
 import com.hazelcast.stabilizer.test.annotations.Verify;
-import com.hazelcast.stabilizer.test.utils.TestUtils;
 import com.hazelcast.stabilizer.test.utils.ThreadSpawner;
 
 import javax.cache.CacheException;
 import java.io.Serializable;
 import java.util.Random;
+
+import static com.hazelcast.stabilizer.tests.helpers.HazelcastTestUtils.isMemberNode;
 
 
 /**
@@ -63,7 +64,7 @@ public class CreateDestroyICacheTest {
         targetInstance = testContext.getTargetInstance();
         basename = testContext.getTestId();
 
-        if (TestUtils.isMemberNode(targetInstance)) {
+        if (isMemberNode(targetInstance)) {
             HazelcastServerCachingProvider hcp = new HazelcastServerCachingProvider();
             cacheManager = new HazelcastServerCacheManager(
                     hcp, targetInstance, hcp.getDefaultURI(), hcp.getDefaultClassLoader(), null);

--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/icache/EntryProcessorICacheTest.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/icache/EntryProcessorICacheTest.java
@@ -19,7 +19,6 @@ import com.hazelcast.stabilizer.test.annotations.Setup;
 import com.hazelcast.stabilizer.test.annotations.Teardown;
 import com.hazelcast.stabilizer.test.annotations.Verify;
 import com.hazelcast.stabilizer.test.annotations.Warmup;
-import com.hazelcast.stabilizer.test.utils.TestUtils;
 import com.hazelcast.stabilizer.test.utils.ThreadSpawner;
 
 import javax.cache.CacheException;
@@ -32,6 +31,7 @@ import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicLong;
 
+import static com.hazelcast.stabilizer.tests.helpers.HazelcastTestUtils.isMemberNode;
 import static org.junit.Assert.assertEquals;
 
 public class EntryProcessorICacheTest {
@@ -59,7 +59,7 @@ public class EntryProcessorICacheTest {
         targetInstance = testContext.getTargetInstance();
 
         CacheManager cacheManager;
-        if (TestUtils.isMemberNode(targetInstance)) {
+        if (isMemberNode(targetInstance)) {
             HazelcastServerCachingProvider hcp = new HazelcastServerCachingProvider();
             cacheManager = new HazelcastServerCacheManager(
                     hcp, targetInstance, hcp.getDefaultURI(), hcp.getDefaultClassLoader(), null);

--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/icache/EvictionICacheTest.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/icache/EvictionICacheTest.java
@@ -15,7 +15,6 @@ import com.hazelcast.stabilizer.test.TestContext;
 import com.hazelcast.stabilizer.test.annotations.Run;
 import com.hazelcast.stabilizer.test.annotations.Setup;
 import com.hazelcast.stabilizer.test.annotations.Verify;
-import com.hazelcast.stabilizer.test.utils.TestUtils;
 import com.hazelcast.stabilizer.test.utils.ThreadSpawner;
 import com.hazelcast.stabilizer.worker.OperationSelector;
 
@@ -25,6 +24,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
 
+import static com.hazelcast.stabilizer.tests.helpers.HazelcastTestUtils.isMemberNode;
 import static junit.framework.Assert.fail;
 
 /*
@@ -76,7 +76,7 @@ public class EvictionICacheTest {
         random.nextBytes(value);
 
         CacheManager cacheManager;
-        if (TestUtils.isMemberNode(targetInstance)) {
+        if (isMemberNode(targetInstance)) {
             HazelcastServerCachingProvider hcp = new HazelcastServerCachingProvider();
             cacheManager = new HazelcastServerCacheManager(
                     hcp, targetInstance, hcp.getDefaultURI(), hcp.getDefaultClassLoader(), null);

--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/icache/ExpiryICacheTest.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/icache/ExpiryICacheTest.java
@@ -42,8 +42,8 @@ import java.util.Random;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static com.hazelcast.stabilizer.test.utils.TestUtils.humanReadableByteCount;
-import static com.hazelcast.stabilizer.test.utils.TestUtils.isMemberNode;
 import static com.hazelcast.stabilizer.test.utils.TestUtils.sleepMs;
+import static com.hazelcast.stabilizer.tests.helpers.HazelcastTestUtils.isMemberNode;
 
 public class ExpiryICacheTest {
 

--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/icache/ExpiryTest.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/icache/ExpiryTest.java
@@ -31,7 +31,6 @@ import com.hazelcast.stabilizer.test.annotations.Run;
 import com.hazelcast.stabilizer.test.annotations.Setup;
 import com.hazelcast.stabilizer.test.annotations.Verify;
 import com.hazelcast.stabilizer.test.annotations.Warmup;
-import com.hazelcast.stabilizer.test.utils.TestUtils;
 import com.hazelcast.stabilizer.test.utils.ThreadSpawner;
 import com.hazelcast.stabilizer.worker.OperationSelector;
 
@@ -45,6 +44,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
+import static com.hazelcast.stabilizer.tests.helpers.HazelcastTestUtils.isMemberNode;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
@@ -91,7 +91,7 @@ public class ExpiryTest {
         targetInstance = testContext.getTargetInstance();
         basename = testContext.getTestId();
 
-        if (TestUtils.isMemberNode(targetInstance)) {
+        if (isMemberNode(targetInstance)) {
             HazelcastServerCachingProvider hcp = new HazelcastServerCachingProvider();
             cacheManager = new HazelcastServerCacheManager(
                     hcp, targetInstance, hcp.getDefaultURI(), hcp.getDefaultClassLoader(), null);

--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/icache/ListenerICacheTest.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/icache/ListenerICacheTest.java
@@ -33,8 +33,8 @@ import java.util.Random;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
-import static com.hazelcast.stabilizer.test.utils.TestUtils.isMemberNode;
 import static com.hazelcast.stabilizer.test.utils.TestUtils.sleepMs;
+import static com.hazelcast.stabilizer.tests.helpers.HazelcastTestUtils.isMemberNode;
 import static junit.framework.Assert.assertEquals;
 
 /*

--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/icache/MangleICacheTest.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/icache/MangleICacheTest.java
@@ -13,7 +13,6 @@ import com.hazelcast.stabilizer.test.TestContext;
 import com.hazelcast.stabilizer.test.annotations.Run;
 import com.hazelcast.stabilizer.test.annotations.Setup;
 import com.hazelcast.stabilizer.test.annotations.Verify;
-import com.hazelcast.stabilizer.test.utils.TestUtils;
 import com.hazelcast.stabilizer.test.utils.ThreadSpawner;
 import com.hazelcast.stabilizer.worker.OperationSelector;
 
@@ -23,6 +22,8 @@ import javax.cache.CacheManager;
 import javax.cache.spi.CachingProvider;
 import java.io.Serializable;
 import java.util.Random;
+
+import static com.hazelcast.stabilizer.tests.helpers.HazelcastTestUtils.isMemberNode;
 
 /**
  * In This tests we are intentionally creating destroying closing and using, cache managers and there caches
@@ -210,7 +211,7 @@ public class MangleICacheTest {
                 currentCachingProvider = cacheManager.getCachingProvider();
                 cacheManager.close();
             }
-            if (TestUtils.isMemberNode(targetInstance)) {
+            if (isMemberNode(targetInstance)) {
                 HazelcastServerCachingProvider hcp = (HazelcastServerCachingProvider) currentCachingProvider;
                 if (hcp == null) {
                     hcp = new HazelcastServerCachingProvider();

--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/icache/PerformanceICacheTest.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/icache/PerformanceICacheTest.java
@@ -18,7 +18,6 @@ import com.hazelcast.stabilizer.test.annotations.Run;
 import com.hazelcast.stabilizer.test.annotations.Setup;
 import com.hazelcast.stabilizer.test.annotations.Teardown;
 import com.hazelcast.stabilizer.test.annotations.Warmup;
-import com.hazelcast.stabilizer.test.utils.TestUtils;
 import com.hazelcast.stabilizer.test.utils.ThreadSpawner;
 
 import javax.cache.CacheException;
@@ -26,6 +25,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicLong;
+
+import static com.hazelcast.stabilizer.tests.helpers.HazelcastTestUtils.isMemberNode;
 
 /**
  * A performance test for the cache. The key is integer and value is a integer
@@ -61,7 +62,7 @@ public class PerformanceICacheTest {
 
         targetInstance = testContext.getTargetInstance();
         CacheManager cacheManager;
-        if (TestUtils.isMemberNode(targetInstance)) {
+        if (isMemberNode(targetInstance)) {
             HazelcastServerCachingProvider hcp = new HazelcastServerCachingProvider();
             cacheManager = new HazelcastServerCacheManager(
                     hcp, targetInstance, hcp.getDefaultURI(), hcp.getDefaultClassLoader(), null);

--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/icache/ReadWriteICacheTest.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/icache/ReadWriteICacheTest.java
@@ -30,7 +30,6 @@ import com.hazelcast.stabilizer.test.annotations.Setup;
 import com.hazelcast.stabilizer.test.annotations.Verify;
 import com.hazelcast.stabilizer.tests.icache.helpers.RecordingCacheLoader;
 import com.hazelcast.stabilizer.tests.icache.helpers.RecordingCacheWriter;
-import com.hazelcast.stabilizer.test.utils.TestUtils;
 import com.hazelcast.stabilizer.test.utils.ThreadSpawner;
 
 import javax.cache.Cache;
@@ -39,6 +38,7 @@ import javax.cache.configuration.MutableConfiguration;
 import java.io.Serializable;
 import java.util.Random;
 
+import static com.hazelcast.stabilizer.tests.helpers.HazelcastTestUtils.isMemberNode;
 import static org.junit.Assert.assertNotNull;
 
 /**
@@ -75,7 +75,7 @@ public class ReadWriteICacheTest {
         targetInstance = testContext.getTargetInstance();
         basename = testContext.getTestId();
 
-        if (TestUtils.isMemberNode(targetInstance)) {
+        if (isMemberNode(targetInstance)) {
             HazelcastServerCachingProvider hcp = new HazelcastServerCachingProvider();
             cacheManager = new HazelcastServerCacheManager(hcp, targetInstance, hcp.getDefaultURI(), hcp.getDefaultClassLoader(), null);
         } else {

--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/icache/StringICacheTest.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/icache/StringICacheTest.java
@@ -40,8 +40,8 @@ import javax.cache.CacheManager;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicLong;
 
-import static com.hazelcast.stabilizer.test.utils.TestUtils.isMemberNode;
-import static com.hazelcast.stabilizer.test.utils.TestUtils.waitClusterSize;
+import static com.hazelcast.stabilizer.tests.helpers.HazelcastTestUtils.isMemberNode;
+import static com.hazelcast.stabilizer.tests.helpers.HazelcastTestUtils.waitClusterSize;
 import static com.hazelcast.stabilizer.tests.helpers.KeyUtils.generateStringKeys;
 
 public class StringICacheTest {

--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/icache/helpers/RecordingCacheLoader.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/icache/helpers/RecordingCacheLoader.java
@@ -20,7 +20,7 @@ public class RecordingCacheLoader<K> implements CacheLoader<K, K>, Serializable 
     @Override
     public K load(final K key) {
 
-        if(loadDelayMs>0){
+        if (loadDelayMs > 0) {
             sleepMs(loadDelayMs);
         }
 
@@ -36,7 +36,7 @@ public class RecordingCacheLoader<K> implements CacheLoader<K, K>, Serializable 
     @Override
     public Map<K, K> loadAll(Iterable<? extends K> keys) {
 
-        if(loadAllDelayMs>0){
+        if (loadAllDelayMs > 0) {
             sleepMs(loadAllDelayMs);
         }
 

--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/map/IntIntMapTest.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/map/IntIntMapTest.java
@@ -30,13 +30,14 @@ import com.hazelcast.stabilizer.test.annotations.Setup;
 import com.hazelcast.stabilizer.test.annotations.Teardown;
 import com.hazelcast.stabilizer.test.annotations.Warmup;
 import com.hazelcast.stabilizer.tests.helpers.KeyUtils;
-import com.hazelcast.stabilizer.test.utils.TestUtils;
 import com.hazelcast.stabilizer.test.utils.ThreadSpawner;
 import com.hazelcast.stabilizer.worker.OperationSelector;
 
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicLong;
 
+import static com.hazelcast.stabilizer.tests.helpers.HazelcastTestUtils.getOperationCountInformation;
+import static com.hazelcast.stabilizer.tests.helpers.HazelcastTestUtils.waitClusterSize;
 import static com.hazelcast.stabilizer.tests.map.IntIntMapTest.Operation.*;
 
 public class IntIntMapTest {
@@ -85,12 +86,12 @@ public class IntIntMapTest {
     @Teardown
     public void teardown() throws Exception {
         map.destroy();
-        log.info(TestUtils.getOperationCountInformation(targetInstance));
+        log.info(getOperationCountInformation(targetInstance));
     }
 
     @Warmup(global = false)
     public void warmup() throws InterruptedException {
-        TestUtils.waitClusterSize(log, targetInstance, minNumberOfMembers);
+        waitClusterSize(log, targetInstance, minNumberOfMembers);
         keys = KeyUtils.generateIntKeys(keyCount, Integer.MAX_VALUE, keyLocality, testContext.getTargetInstance());
 
         Random random = new Random();

--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/map/MapDataIntegrityTest.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/map/MapDataIntegrityTest.java
@@ -13,12 +13,12 @@ import com.hazelcast.stabilizer.test.TestContext;
 import com.hazelcast.stabilizer.test.annotations.Run;
 import com.hazelcast.stabilizer.test.annotations.Setup;
 import com.hazelcast.stabilizer.test.annotations.Verify;
-import com.hazelcast.stabilizer.test.utils.TestUtils;
 import com.hazelcast.stabilizer.test.utils.ThreadSpawner;
 
 import java.util.Random;
 import java.util.Set;
 
+import static com.hazelcast.stabilizer.tests.helpers.HazelcastTestUtils.isMemberNode;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNotNull;
 
@@ -58,7 +58,7 @@ public class MapDataIntegrityTest {
         Random random = new Random();
         random.nextBytes(value);
 
-        if(mapLoad && TestUtils.isMemberNode(targetInstance)){
+        if(mapLoad && isMemberNode(targetInstance)){
 
             PartitionService partitionService = targetInstance.getPartitionService();
             final Set<Partition> partitionSet = partitionService.getPartitions();
@@ -135,7 +135,7 @@ public class MapDataIntegrityTest {
 
     @Verify(global = false)
     public void verify() throws Exception {
-        if(TestUtils.isMemberNode(targetInstance)){
+        if(isMemberNode(targetInstance)){
             log.info(id + ": cluster size =" + targetInstance.getCluster().getMembers().size());
         }
 

--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/map/MapHeapHogTest.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/map/MapHeapHogTest.java
@@ -15,8 +15,8 @@ import com.hazelcast.stabilizer.test.utils.ThreadSpawner;
 import java.util.concurrent.TimeUnit;
 
 import static com.hazelcast.stabilizer.test.utils.TestUtils.humanReadableByteCount;
-import static com.hazelcast.stabilizer.test.utils.TestUtils.isMemberNode;
-import static com.hazelcast.stabilizer.test.utils.TestUtils.nextKeyOwnedBy;
+import static com.hazelcast.stabilizer.tests.helpers.HazelcastTestUtils.isMemberNode;
+import static com.hazelcast.stabilizer.tests.helpers.HazelcastTestUtils.nextKeyOwnedBy;
 
 public class MapHeapHogTest {
 

--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/map/MapStoreTest.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/map/MapStoreTest.java
@@ -8,7 +8,6 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.spi.exception.DistributedObjectDestroyedException;
 import com.hazelcast.stabilizer.test.utils.AssertTask;
-import com.hazelcast.stabilizer.test.utils.TestUtils;
 import com.hazelcast.stabilizer.tests.map.helpers.MapOperationsCount;
 import com.hazelcast.stabilizer.tests.map.helpers.MapStoreWithCounter;
 import com.hazelcast.stabilizer.test.TestContext;
@@ -20,7 +19,8 @@ import com.hazelcast.stabilizer.test.utils.ThreadSpawner;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
-import static com.hazelcast.stabilizer.test.utils.TestUtils.isMemberNode;
+import static com.hazelcast.stabilizer.test.utils.TestUtils.assertTrueEventually;
+import static com.hazelcast.stabilizer.tests.helpers.HazelcastTestUtils.isMemberNode;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNull;
 
@@ -172,7 +172,7 @@ public class MapStoreTest {
             log.info(basename + ": map size  =" + map.size());
             log.info(basename + ": " + mapStore);
 
-            TestUtils.assertTrueEventually(new AssertTask() {
+            assertTrueEventually(new AssertTask() {
                 @Override
                 public void run() throws Exception {
 

--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/map/MapTimeToLiveTest.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/map/MapTimeToLiveTest.java
@@ -22,7 +22,6 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.spi.exception.DistributedObjectDestroyedException;
 import com.hazelcast.stabilizer.test.utils.AssertTask;
-import com.hazelcast.stabilizer.test.utils.TestUtils;
 import com.hazelcast.stabilizer.tests.map.helpers.MapOperationsCount;
 import com.hazelcast.stabilizer.test.TestContext;
 import com.hazelcast.stabilizer.test.TestRunner;
@@ -30,12 +29,11 @@ import com.hazelcast.stabilizer.test.annotations.Run;
 import com.hazelcast.stabilizer.test.annotations.Setup;
 import com.hazelcast.stabilizer.test.annotations.Verify;
 import com.hazelcast.stabilizer.test.utils.ThreadSpawner;
-import junit.framework.Assert;
 
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
-import static junit.framework.Assert.assertNull;
+import static com.hazelcast.stabilizer.test.utils.TestUtils.assertTrueEventually;
 import static org.junit.Assert.assertEquals;
 
 /**
@@ -133,7 +131,7 @@ public class MapTimeToLiveTest {
 
         final IMap map = targetInstance.getMap(basename);
 
-        TestUtils.assertTrueEventually(new AssertTask() {
+        assertTrueEventually(new AssertTask() {
             @Override
             public void run() throws Exception {
                 assertEquals(basename + ": Map Size not 0, some TTL events not processed", 0, map.size());

--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/map/SplitClusterDataTest.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/map/SplitClusterDataTest.java
@@ -11,7 +11,7 @@ import com.hazelcast.stabilizer.test.annotations.Verify;
 import com.hazelcast.stabilizer.test.annotations.Warmup;
 import com.hazelcast.stabilizer.test.utils.ThreadSpawner;
 
-import static com.hazelcast.stabilizer.test.utils.TestUtils.waitClusterSize;
+import static com.hazelcast.stabilizer.tests.helpers.HazelcastTestUtils.waitClusterSize;
 import static org.junit.Assert.assertEquals;
 
 public class SplitClusterDataTest {

--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/map/SqlPredicateTest.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/map/SqlPredicateTest.java
@@ -16,7 +16,6 @@ import com.hazelcast.stabilizer.test.annotations.Run;
 import com.hazelcast.stabilizer.test.annotations.Setup;
 import com.hazelcast.stabilizer.test.annotations.Teardown;
 import com.hazelcast.stabilizer.test.annotations.Warmup;
-import com.hazelcast.stabilizer.test.utils.TestUtils;
 import com.hazelcast.stabilizer.test.utils.ThreadSpawner;
 import com.hazelcast.stabilizer.worker.Metronome;
 import com.hazelcast.stabilizer.worker.SimpleMetronome;
@@ -24,6 +23,8 @@ import com.hazelcast.stabilizer.worker.SimpleMetronome;
 import java.io.IOException;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicLong;
+
+import static com.hazelcast.stabilizer.tests.helpers.HazelcastTestUtils.getOperationCountInformation;
 
 public class SqlPredicateTest {
 
@@ -56,7 +57,7 @@ public class SqlPredicateTest {
     @Teardown
     public void teardown() throws Exception {
         map.destroy();
-        log.info(TestUtils.getOperationCountInformation(targetInstance));
+        log.info(getOperationCountInformation(targetInstance));
     }
 
     @Warmup(global = false)

--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/map/StringMapTest.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/map/StringMapTest.java
@@ -31,13 +31,15 @@ import com.hazelcast.stabilizer.test.annotations.Setup;
 import com.hazelcast.stabilizer.test.annotations.Teardown;
 import com.hazelcast.stabilizer.test.annotations.Warmup;
 import com.hazelcast.stabilizer.tests.helpers.KeyUtils;
-import com.hazelcast.stabilizer.test.utils.TestUtils;
 import com.hazelcast.stabilizer.test.utils.ThreadSpawner;
 import com.hazelcast.stabilizer.worker.Metronome;
 import com.hazelcast.stabilizer.worker.SimpleMetronome;
 
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicLong;
+
+import static com.hazelcast.stabilizer.tests.helpers.HazelcastTestUtils.getOperationCountInformation;
+import static com.hazelcast.stabilizer.tests.helpers.HazelcastTestUtils.waitClusterSize;
 
 public class StringMapTest {
 
@@ -90,12 +92,12 @@ public class StringMapTest {
     @Teardown
     public void teardown() throws Exception {
         map.destroy();
-        log.info(TestUtils.getOperationCountInformation(targetInstance));
+        log.info(getOperationCountInformation(targetInstance));
     }
 
     @Warmup(global = false)
     public void warmup() throws InterruptedException {
-        TestUtils.waitClusterSize(log, targetInstance, minNumberOfMembers);
+        waitClusterSize(log, targetInstance, minNumberOfMembers);
         keys = KeyUtils.generateStringKeys(keyCount, keyLength, keyLocality, testContext.getTargetInstance());
         values = StringUtils.generateStrings(valueCount, valueLength);
 

--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/synthetic/SyntheticTest.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/synthetic/SyntheticTest.java
@@ -31,10 +31,10 @@ import java.util.Collections;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicLong;
 
-import static com.hazelcast.stabilizer.test.utils.TestUtils.getNode;
-import static com.hazelcast.stabilizer.test.utils.TestUtils.getOperationCountInformation;
-import static com.hazelcast.stabilizer.test.utils.TestUtils.getPartitionDistributionInformation;
-import static com.hazelcast.stabilizer.test.utils.TestUtils.isClient;
+import static com.hazelcast.stabilizer.tests.helpers.HazelcastTestUtils.getNode;
+import static com.hazelcast.stabilizer.tests.helpers.HazelcastTestUtils.getOperationCountInformation;
+import static com.hazelcast.stabilizer.tests.helpers.HazelcastTestUtils.getPartitionDistributionInformation;
+import static com.hazelcast.stabilizer.tests.helpers.HazelcastTestUtils.isClient;
 
 /**
  * The SyntheticBackPressureTest tests back pressure.

--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/topic/ITopicTest.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/topic/ITopicTest.java
@@ -15,7 +15,6 @@ import com.hazelcast.stabilizer.test.annotations.Setup;
 import com.hazelcast.stabilizer.test.annotations.Teardown;
 import com.hazelcast.stabilizer.test.annotations.Verify;
 import com.hazelcast.stabilizer.test.utils.AssertTask;
-import com.hazelcast.stabilizer.test.utils.TestUtils;
 import com.hazelcast.stabilizer.test.utils.ThreadSpawner;
 
 import java.util.LinkedList;
@@ -23,6 +22,7 @@ import java.util.List;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicLong;
 
+import static com.hazelcast.stabilizer.test.utils.TestUtils.assertTrueEventually;
 import static com.hazelcast.stabilizer.test.utils.TestUtils.sleepRandomNanos;
 import static org.junit.Assert.assertEquals;
 
@@ -95,7 +95,7 @@ public class ITopicTest {
 
         final long expectedCount = totalExpectedCounter.get();
 
-        TestUtils.assertTrueEventually(new AssertTask() {
+        assertTrueEventually(new AssertTask() {
             @Override
             public void run() throws Exception {
                 long actualCount = 0;


### PR DESCRIPTION
Another PR for the long term goal to make the Stabilizer core module independent from Hazelcast dependencies (this will ease the use of other frameworks):
* Stabilizer uses log4j for logging now (instead of ILogger from Hazelcast)
* most Hazelcast specific util methods have been moved from `com.hazelcast.stabilizer.test.TestUtils` to `com.hazelcast.stabilizer.tests.helpers.HazelcastTestUtils`

I did a local test run with Hazelcast 3.4 which compiled and compared the log files, which look exactly the same.