### PR TITLE
Created base class for stabilizer tests.

### DIFF
--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/StabilizerAbstractTest.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/StabilizerAbstractTest.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2008-2013, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hazelcast.stabilizer.tests;
+
+import com.hazelcast.core.ExecutionCallback;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IAtomicLong;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+import com.hazelcast.stabilizer.test.TestContext;
+import com.hazelcast.stabilizer.test.annotations.Performance;
+import com.hazelcast.stabilizer.test.annotations.Run;
+import com.hazelcast.stabilizer.test.annotations.Setup;
+import com.hazelcast.stabilizer.test.annotations.Teardown;
+import com.hazelcast.stabilizer.test.annotations.Verify;
+import com.hazelcast.stabilizer.test.utils.ExceptionReporter;
+import com.hazelcast.stabilizer.test.utils.ThreadSpawner;
+import com.hazelcast.stabilizer.tests.helpers.HazelcastTestUtils;
+import com.hazelcast.stabilizer.worker.OperationSelector;
+
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicLong;
+
+public abstract class StabilizerAbstractTest {
+
+    public static enum BaseOperation {
+        PUT,
+        PUT_ASYNC,
+        GET,
+        GET_ASYNC
+    }
+
+    private final static ILogger log = Logger.getLogger(StabilizerAbstractTest.class);
+
+    // Properties
+    public int threadCount = 10;
+    public int logFrequency = 10000;
+    public int performanceUpdateFrequency = 1000;
+
+    // Member variables
+    private TestContext testContext;
+    private HazelcastInstance hazelcastInstance;
+    private IAtomicLong verifyCounter;
+    private AtomicLong performanceCounter = new AtomicLong();
+    private OperationSelector<BaseOperation> selector = new OperationSelector<BaseOperation>();
+
+    protected StabilizerAbstractTest addOperation(BaseOperation operation, double probability) {
+        selector.addOperation(operation, probability);
+        return this;
+    }
+
+    protected void addOperationRemainingProbability(BaseOperation operation) {
+        selector.addOperationRemainingProbability(operation);
+    }
+
+    @Setup
+    public void setup(TestContext context) throws Exception {
+        testContext = context;
+        hazelcastInstance = context.getTargetInstance();
+        verifyCounter = hazelcastInstance.getAtomicLong("VerifyCounter:" + context.getTestId());
+
+        afterSetup(hazelcastInstance);
+    }
+
+    @Teardown
+    public void teardown() throws Exception {
+        beforeTeardown();
+
+        verifyCounter.destroy();
+        log.info(HazelcastTestUtils.getOperationCountInformation(hazelcastInstance));
+    }
+
+    @Verify
+    public void verify() throws Exception {
+        doVerify(hazelcastInstance, verifyCounter.get());
+    }
+
+    @Performance
+    public long getOperationCount() {
+        return performanceCounter.get();
+    }
+
+    @Run
+    public void run() {
+        ThreadSpawner spawner = new ThreadSpawner(testContext.getTestId());
+        for (int i = 0; i < threadCount; i++) {
+            spawner.spawn(createWorker());
+        }
+        spawner.awaitCompletion();
+    }
+
+    protected abstract void afterSetup(HazelcastInstance hazelcastInstance) throws Exception;
+
+    protected abstract void beforeTeardown() throws Exception;
+
+    protected abstract void doVerify(HazelcastInstance hazelcastInstance, long verifyCount) throws Exception;
+
+    protected abstract BaseWorker createWorker();
+
+    protected abstract class BaseWorker implements Runnable {
+        private final Random random = new Random();
+
+        long iterations = 0;
+        long verifyCounterIncrements = 0;
+
+        @Override
+        public void run() {
+            while (!testContext.isStopped()) {
+                doRun(selector.select());
+
+                incrementIteration();
+            }
+            performanceCounter.addAndGet(iterations % performanceUpdateFrequency);
+            verifyCounter.addAndGet(verifyCounterIncrements);
+        }
+
+        protected abstract void doRun(BaseOperation baseOperation);
+
+        protected int getRandomInt(int upperBound) {
+            return random.nextInt(upperBound);
+        }
+
+        protected void incrementVerifyCounter() {
+            verifyCounterIncrements++;
+        }
+
+        void incrementIteration() {
+            iterations++;
+            if (iterations % logFrequency == 0) {
+                log.info(Thread.currentThread().getName() + " At iteration: " + iterations);
+            }
+            if (iterations % performanceUpdateFrequency == 0) {
+                performanceCounter.addAndGet(performanceUpdateFrequency);
+            }
+        }
+    }
+
+    protected abstract class AsyncBaseWorker<T> extends BaseWorker implements ExecutionCallback<T> {
+
+        @Override
+        public void run() {
+            while (!testContext.isStopped()) {
+                doRun(selector.select());
+            }
+            performanceCounter.addAndGet(iterations % performanceUpdateFrequency);
+            verifyCounter.addAndGet(verifyCounterIncrements);
+        }
+
+        @Override
+        public void onResponse(T type) {
+            incrementIteration();
+
+            onAsyncResponse(type);
+        }
+
+        @Override
+        public void onFailure(Throwable throwable) {
+            reportException(throwable);
+        }
+
+        protected abstract void onAsyncResponse(T type);
+
+        protected void reportException(Throwable throwable) {
+            ExceptionReporter.report(testContext.getTestId(), throwable);
+        }
+    }
+}

--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/concurrent/atomiclong/AsyncAtomicLongTest.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/concurrent/atomiclong/AsyncAtomicLongTest.java
@@ -16,189 +16,129 @@
 package com.hazelcast.stabilizer.tests.concurrent.atomiclong;
 
 import com.hazelcast.core.AsyncAtomicLong;
-import com.hazelcast.core.ExecutionCallback;
+import com.hazelcast.core.DistributedObject;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IAtomicLong;
 import com.hazelcast.core.ICompletableFuture;
-import com.hazelcast.logging.ILogger;
-import com.hazelcast.logging.Logger;
 import com.hazelcast.stabilizer.Utils;
-import com.hazelcast.stabilizer.test.TestContext;
 import com.hazelcast.stabilizer.test.TestRunner;
-import com.hazelcast.stabilizer.test.annotations.Performance;
-import com.hazelcast.stabilizer.test.annotations.Run;
-import com.hazelcast.stabilizer.test.annotations.Setup;
-import com.hazelcast.stabilizer.test.annotations.Teardown;
-import com.hazelcast.stabilizer.test.annotations.Verify;
 import com.hazelcast.stabilizer.tests.helpers.KeyLocality;
 import com.hazelcast.stabilizer.tests.helpers.KeyUtils;
 import com.hazelcast.stabilizer.test.utils.AssertTask;
-import com.hazelcast.stabilizer.test.utils.ExceptionReporter;
-import com.hazelcast.stabilizer.test.utils.ThreadSpawner;
+import com.hazelcast.stabilizer.tests.StabilizerAbstractTest;
 
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Random;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.atomic.AtomicLong;
 
 import static com.hazelcast.stabilizer.test.utils.TestUtils.assertTrueEventually;
-import static com.hazelcast.stabilizer.tests.helpers.HazelcastTestUtils.getOperationCountInformation;
 import static org.junit.Assert.assertEquals;
 
-public class AsyncAtomicLongTest {
+public class AsyncAtomicLongTest extends StabilizerAbstractTest {
 
-    private final static ILogger log = Logger.getLogger(AsyncAtomicLongTest.class);
+    private static final String KEY_PREFIX = "AsyncAtomicLongTest";
 
-    //props
+    // Properties
     public int countersLength = 1000;
-    public int threadCount = 10;
-    public int logFrequency = 10000;
-    public String basename = "atomiclong";
+    public String basename = "atomicLong";
     public KeyLocality keyLocality = KeyLocality.Random;
-    public int writePercentage = 100;
+    public double writeProb = 1.0;
     public int assertEventuallySeconds = 300;
     public int batchSize = -1;
 
-    private IAtomicLong totalCounter;
     private AsyncAtomicLong[] counters;
-    private AtomicLong operations = new AtomicLong();
-    private TestContext context;
-    private HazelcastInstance targetInstance;
+    private String serviceName;
 
-    @Setup
-    public void setup(TestContext context) throws Exception {
-        this.context = context;
-
-        if (writePercentage < 0) {
-            throw new IllegalArgumentException("Write percentage can't be smaller than 0");
-        }
-
-        if (writePercentage > 100) {
-            throw new IllegalArgumentException("Write percentage can't be larger than 100");
-        }
-
-        targetInstance = context.getTargetInstance();
-
-        totalCounter = targetInstance.getAtomicLong(context.getTestId() + ":TotalCounter");
+    @Override
+    public void afterSetup(HazelcastInstance hazelcastInstance) throws Exception {
         counters = new AsyncAtomicLong[countersLength];
-        for (int k = 0; k < counters.length; k++) {
-            String key = KeyUtils.generateStringKey(8, keyLocality, targetInstance);
-            counters[k] = (AsyncAtomicLong) targetInstance.getAtomicLong(key);
+        for (int i = 0; i < counters.length; i++) {
+            String key = KEY_PREFIX + KeyUtils.generateStringKey(8, keyLocality, hazelcastInstance);
+            counters[i] = (AsyncAtomicLong) hazelcastInstance.getAtomicLong(key);
         }
+        serviceName = counters[0].getServiceName();
+
+        addOperation(BaseOperation.PUT, writeProb);
+        addOperationRemainingProbability(BaseOperation.GET);
     }
 
-    @Teardown
-    public void teardown() throws Exception {
+    @Override
+    public void beforeTeardown() throws Exception {
         for (IAtomicLong counter : counters) {
             counter.destroy();
         }
-        totalCounter.destroy();
-        log.info(getOperationCountInformation(targetInstance));
     }
 
-    @Run
-    public void run() {
-        ThreadSpawner spawner = new ThreadSpawner(context.getTestId());
-        for (int k = 0; k < threadCount; k++) {
-            spawner.spawn(new Worker());
-        }
-        spawner.awaitCompletion();
-    }
-
-    @Verify
-    public void verify() {
-        final long expected = totalCounter.get();
-
-        // since the operations are asynchronous, we have no idea when they complete.
+    @Override
+    public void doVerify(final HazelcastInstance hazelcastInstance, final long verifyCounter) {
+        // since the operations are asynchronous, we have no idea when they complete
         assertTrueEventually(new AssertTask() {
             @Override
             public void run() throws Exception {
-                //hack to prevent overloading the system with get calls. Else it is done many times a second.
+                // hack to prevent overloading the system with get calls. Else it is done many times a second
                 Utils.sleepSeconds(10);
 
                 long actual = 0;
-                for (IAtomicLong counter : counters) {
-                    actual += counter.get();
+                for (DistributedObject distributedObject : hazelcastInstance.getDistributedObjects()) {
+                    String key = distributedObject.getName();
+                    if ((distributedObject.getServiceName().equals(serviceName) && key.startsWith(KEY_PREFIX))) {
+                        actual += hazelcastInstance.getAtomicLong(key).get();
+                    }
                 }
-                assertEquals(expected, actual);
+                assertEquals(verifyCounter, actual);
             }
         }, assertEventuallySeconds);
     }
 
-    @Performance
-    public long getOperationCount() {
-        return operations.get();
+    @Override
+    public BaseWorker createWorker() {
+        return new Worker();
     }
 
-    private class Worker implements Runnable, ExecutionCallback {
-        private final Random random = new Random();
+    private class Worker extends AsyncBaseWorker<Long> {
+        private final List<ICompletableFuture<Long>> batch = new LinkedList<ICompletableFuture<Long>>();
 
         @Override
-        public void run() {
-            long iteration = 0;
-            long increments = 0;
+        protected void doRun(BaseOperation baseOperation) {
+            AsyncAtomicLong counter = getRandomCounter();
 
-            List<ICompletableFuture> batch = new LinkedList<ICompletableFuture>();
-            while (!context.isStopped()) {
-                AsyncAtomicLong counter = getRandomCounter();
-                ICompletableFuture<Long> future;
-                if (shouldWrite(iteration)) {
-                    increments++;
+            ICompletableFuture<Long> future;
+            switch (baseOperation) {
+                case PUT:
+                    incrementVerifyCounter();
                     future = counter.asyncIncrementAndGet();
-                } else {
+                    break;
+                case GET:
                     future = counter.asyncGet();
-                }
+                    break;
+                default:
+                    throw new UnsupportedOperationException();
+            }
+            future.andThen(this);
 
-                future.andThen(this);
+            if (batchSize > 0) {
+                batch.add(future);
 
-                if (batchSize > 0) {
-                    batch.add(future);
-
-                    if (batch.size() == batchSize) {
-                        for (ICompletableFuture f : batch) {
-                            try {
-                                f.get();
-                            } catch (InterruptedException e) {
-                                throw new RuntimeException(e);
-                            } catch (ExecutionException e) {
-                                throw new RuntimeException(e);
-                            }
+                if (batch.size() == batchSize) {
+                    for (ICompletableFuture batchFuture : batch) {
+                        try {
+                            batchFuture.get();
+                        } catch (InterruptedException e) {
+                            throw new RuntimeException(e);
+                        } catch (ExecutionException e) {
+                            throw new RuntimeException(e);
                         }
                     }
                 }
-
-                iteration++;
-                if (iteration % logFrequency == 0) {
-                    log.info(Thread.currentThread().getName() + " At iteration: " + iteration);
-                }
             }
-            totalCounter.addAndGet(increments);
         }
 
         @Override
-        public void onResponse(Object response) {
-            operations.addAndGet(1);
-        }
-
-        @Override
-        public void onFailure(Throwable t) {
-            ExceptionReporter.report(context.getTestId(), t);
-        }
-
-        private boolean shouldWrite(long iteration) {
-            if (writePercentage == 0) {
-                return false;
-            } else if (writePercentage == 100) {
-                return true;
-            } else {
-                return random.nextInt(100) <= writePercentage;
-            }
+        protected void onAsyncResponse(Long type) {
         }
 
         private AsyncAtomicLong getRandomCounter() {
-            int index = random.nextInt(counters.length);
-            return counters[index];
+            return counters[getRandomInt(counters.length)];
         }
     }
 


### PR DESCRIPTION
First attempt to create a base class for stabilizer tests.

The major change to stabilizer is the search for annotated methods in superclasses. I didn't mess with the `assertExactlyOne` or `assertAtMostOne`, the first found method wins. So you can always overwrite a method from the base class.

Beside that I was hunting phantoms most of the time, which I finally ruled out by doing comparative runs with the actual master. The `AsyncAtomicLongTest` seems to be broken and causes OOME on my machine. So this was a bad candidate to start with (I just picked the first test in the test module, also it looked simple enough). The `AtomicLongTest` had a constant failure in the verify stage. I fixed that (maybe not very elegant, but it works now). Also there seems to be an issue in the teardown phase if you have more than one member on a node (`Hazelcast instance is not active!`, could be the same as #370). But all of these issues seem not be related with my actual changes. A run with `AtomicLongTest` finishes without any new problems.

Content of my `test.properties`
```
AtomicLongTest@class=com.hazelcast.stabilizer.tests.concurrent.atomiclong.AtomicLongTest
```