### PR TITLE
Enhancement and cleanup of TestContainer

### DIFF
--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/worker/TestContainer.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/worker/TestContainer.java
@@ -2,11 +2,11 @@ package com.hazelcast.stabilizer.worker;
 
 import com.hazelcast.stabilizer.common.messaging.Message;
 import com.hazelcast.stabilizer.probes.probes.IntervalProbe;
+import com.hazelcast.stabilizer.probes.probes.Probes;
 import com.hazelcast.stabilizer.probes.probes.ProbesConfiguration;
 import com.hazelcast.stabilizer.probes.probes.Result;
 import com.hazelcast.stabilizer.probes.probes.SimpleProbe;
 import com.hazelcast.stabilizer.probes.probes.impl.DisabledResult;
-import com.hazelcast.stabilizer.test.exceptions.IllegalTestException;
 import com.hazelcast.stabilizer.test.TestContext;
 import com.hazelcast.stabilizer.test.annotations.Name;
 import com.hazelcast.stabilizer.test.annotations.Performance;
@@ -16,40 +16,46 @@ import com.hazelcast.stabilizer.test.annotations.Setup;
 import com.hazelcast.stabilizer.test.annotations.Teardown;
 import com.hazelcast.stabilizer.test.annotations.Verify;
 import com.hazelcast.stabilizer.test.annotations.Warmup;
+import com.hazelcast.stabilizer.test.exceptions.IllegalTestException;
+import com.hazelcast.stabilizer.worker.utils.AnnotationFilter.TeardownFilter;
+import com.hazelcast.stabilizer.worker.utils.AnnotationFilter.VerifyFilter;
+import com.hazelcast.stabilizer.worker.utils.AnnotationFilter.WarmupFilter;
 import com.hazelcast.util.Clock;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
 import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import com.hazelcast.stabilizer.probes.probes.Probes;
 
+import static com.hazelcast.stabilizer.worker.utils.ReflectionUtils.getMandatoryVoidMethodWithoutArgs;
+import static com.hazelcast.stabilizer.worker.utils.ReflectionUtils.getOptionalMethodWithoutArgs;
+import static com.hazelcast.stabilizer.worker.utils.ReflectionUtils.getOptionalVoidMethodSkipArgsCheck;
+import static com.hazelcast.stabilizer.worker.utils.ReflectionUtils.getOptionalVoidMethodWithoutArgs;
+import static com.hazelcast.stabilizer.worker.utils.ReflectionUtils.injectObjectToInstance;
+import static com.hazelcast.stabilizer.worker.utils.ReflectionUtils.invokeMethod;
 import static java.lang.String.format;
 
 /**
  * Since the test is based on annotations, there is no API we can call very easily.
  * That is the task of this test container.
  *
- * @param <T>
+ * @param <T> Class of type TextContext
  */
 public class TestContainer<T extends TestContext> {
 
-    private final Object testObject;
-    private final Class<? extends Object> clazz;
+    private final Object testClassInstance;
+    private final Class<?> testClassType;
     private final T testContext;
     private final ProbesConfiguration probesConfiguration;
 
-    private Method runMethod;
-    private Method setupMethod;
+    private final Map<String, SimpleProbe<?, ?>> probeMap = new ConcurrentHashMap<String, SimpleProbe<?, ?>>();
 
-    private Method localTeardownMethod;
-    private Method globalTeardownMethod;
+    private Method runMethod;
+
+    private Method setupMethod;
+    private Object[] setupArguments;
 
     private Method localWarmupMethod;
     private Method globalWarmupMethod;
@@ -57,11 +63,11 @@ public class TestContainer<T extends TestContext> {
     private Method localVerifyMethod;
     private Method globalVerifyMethod;
 
+    private Method localTeardownMethod;
+    private Method globalTeardownMethod;
+
     private Method operationCountMethod;
     private Method messageConsumerMethod;
-
-    private Map<String, SimpleProbe<?, ?>> probeMap = new ConcurrentHashMap<String, SimpleProbe<?, ?>>();
-    private Object[] setupArguments;
 
     public TestContainer(Object testObject, T testContext, ProbesConfiguration probesConfiguration) {
         if (testObject == null) {
@@ -72,8 +78,8 @@ public class TestContainer<T extends TestContext> {
         }
 
         this.testContext = testContext;
-        this.testObject = testObject;
-        this.clazz = testObject.getClass();
+        this.testClassInstance = testObject;
+        this.testClassType = testObject.getClass();
         this.probesConfiguration = probesConfiguration;
 
         initMethods();
@@ -92,32 +98,8 @@ public class TestContainer<T extends TestContext> {
         return results;
     }
 
-    private void initMethods() {
-        initRunMethod();
-        initSetupMethod();
-
-        initLocalTeardownMethod();
-        initGlobalTeardownMethod();
-
-        initLocalWarmupMethod();
-        initGlobalWarmupMethod();
-
-        initLocalVerifyMethod();
-        initGlobalVerifyMethod();
-
-        initGetOperationCountMethod();
-
-        initMessageConsumerMethod();
-        injectDependencies();
-    }
-
     public T getTestContext() {
         return testContext;
-    }
-
-    public long getOperationCount() throws Throwable {
-        Long count = invoke(operationCountMethod);
-        return count == null ? -1 : count;
     }
 
     public void run() throws Throwable {
@@ -125,7 +107,7 @@ public class TestContainer<T extends TestContext> {
         for (SimpleProbe probe : probeMap.values()) {
             probe.startProbing(now);
         }
-        invoke(runMethod);
+        invokeMethod(testClassInstance, runMethod);
         now = Clock.currentTimeMillis();
         for (SimpleProbe probe : probeMap.values()) {
             probe.stopProbing(now);
@@ -133,79 +115,160 @@ public class TestContainer<T extends TestContext> {
     }
 
     public void setup() throws Throwable {
-        invoke(setupMethod, setupArguments);
-    }
-
-    public void globalTeardown() throws Throwable {
-        invoke(globalTeardownMethod);
-    }
-
-    public void localTeardown() throws Throwable {
-        invoke(localTeardownMethod);
-    }
-
-    public void localVerify() throws Throwable {
-        invoke(localVerifyMethod);
-    }
-
-    public void globalVerify() throws Throwable {
-        invoke(globalVerifyMethod);
+        invokeMethod(testClassInstance, setupMethod, setupArguments);
     }
 
     public void localWarmup() throws Throwable {
-        invoke(localWarmupMethod);
+        invokeMethod(testClassInstance, localWarmupMethod);
     }
 
     public void globalWarmup() throws Throwable {
-        invoke(globalWarmupMethod);
+        invokeMethod(testClassInstance, globalWarmupMethod);
+    }
+
+    public void localVerify() throws Throwable {
+        invokeMethod(testClassInstance, localVerifyMethod);
+    }
+
+    public void globalVerify() throws Throwable {
+        invokeMethod(testClassInstance, globalVerifyMethod);
+    }
+
+    public void globalTeardown() throws Throwable {
+        invokeMethod(testClassInstance, globalTeardownMethod);
+    }
+
+    public void localTeardown() throws Throwable {
+        invokeMethod(testClassInstance, localTeardownMethod);
+    }
+
+    public long getOperationCount() throws Throwable {
+        Long count = invokeMethod(testClassInstance, operationCountMethod);
+        return (count == null ? -1 : count);
     }
 
     public void sendMessage(Message message) throws Throwable {
-        invoke(messageConsumerMethod, message);
+        invokeMethod(testClassInstance, messageConsumerMethod, message);
     }
 
-    private <E> E invoke(Method method, Object... args) throws Throwable {
-        if (method == null) {
-            return null;
+    private void initMethods() {
+        runMethod = getMandatoryVoidMethodWithoutArgs(testClassType, Run.class);
+
+        setupMethod = getOptionalVoidMethodSkipArgsCheck(testClassType, Setup.class);
+        if (setupMethod != null) {
+            assertSetupArguments(setupMethod);
+            setupArguments = getSetupArguments(setupMethod);
         }
 
-        try {
-            return (E) method.invoke(testObject, args);
-        } catch (InvocationTargetException e) {
-            throw e.getCause();
+        localWarmupMethod = getOptionalVoidMethodWithoutArgs(testClassType, Warmup.class, new WarmupFilter(false));
+        globalWarmupMethod = getOptionalVoidMethodWithoutArgs(testClassType, Warmup.class, new WarmupFilter(true));
+
+        localVerifyMethod = getOptionalVoidMethodWithoutArgs(testClassType, Verify.class, new VerifyFilter(false));
+        globalVerifyMethod = getOptionalVoidMethodWithoutArgs(testClassType, Verify.class, new VerifyFilter(true));
+
+        localTeardownMethod = getOptionalVoidMethodWithoutArgs(testClassType, Teardown.class, new TeardownFilter(false));
+        globalTeardownMethod = getOptionalVoidMethodWithoutArgs(testClassType, Teardown.class, new TeardownFilter(true));
+
+        operationCountMethod = getOptionalMethodWithoutArgs(testClassType, Performance.class, Long.TYPE);
+        messageConsumerMethod = getOptionalVoidMethodSkipArgsCheck(testClassType, Receive.class);
+        if (messageConsumerMethod != null) {
+            assertArguments(messageConsumerMethod, Message.class);
         }
+
+        injectDependencies();
     }
 
-    private void initSetupMethod() {
-        List<Method> methods = findMethod(Setup.class);
-        assertAtMostOne(methods, Setup.class);
-
-        if (methods.isEmpty()) {
+    private void assertSetupArguments(Method method) {
+        Class<?>[] parameterTypes = method.getParameterTypes();
+        if (parameterTypes.length < 1) {
             return;
         }
 
-        Method method = methods.get(0);
-        method.setAccessible(true);
-        assertNotStatic(method);
-        assertVoidReturnType(method);
-        assertSetupArguments(method);
+        boolean testContextFound = false;
+        boolean illegalArgumentFound = false;
+        for (Class<?> parameterType : parameterTypes) {
+            boolean isObject = parameterType.isAssignableFrom(Object.class);
+            if (!isObject && parameterType.isAssignableFrom(TestContext.class)) {
+                testContextFound = true;
+            } else if (!parameterType.isAssignableFrom(IntervalProbe.class) || isObject) {
+                illegalArgumentFound = true;
+                break;
+            }
+        }
+        if (!testContextFound || illegalArgumentFound) {
+            throw new IllegalTestException(
+                    format("Method %s.%s must have argument of type %s and zero or more arguments of type %s", testClassType,
+                            method, TestContext.class, SimpleProbe.class));
+        }
+    }
 
-        initSetupArguments(method);
-        setupMethod = method;
+    private void assertArguments(Method method, Class<?>... arguments) {
+        Class<?>[] parameterTypes = method.getParameterTypes();
+        if (parameterTypes.length != arguments.length) {
+            throw new IllegalTestException(
+                    format("Method %s must have %s arguments, but %s arguments found", method, arguments.length,
+                            parameterTypes.length));
+        }
+
+        for (int i = 0; i < arguments.length; i++) {
+            if (!parameterTypes[i].isAssignableFrom(arguments[i])) {
+                throw new IllegalTestException(
+                        format("Method %s has argument of type %s at index %d where type %s is expected", method,
+                                parameterTypes[i], i + 1, arguments[i]));
+            }
+        }
+    }
+
+    private Object[] getSetupArguments(Method method) {
+        Class<?>[] parameterTypes = method.getParameterTypes();
+        Annotation[][] parameterAnnotations = method.getParameterAnnotations();
+        Object[] arguments = new Object[parameterTypes.length];
+        for (int i = 0; i < parameterTypes.length; i++) {
+            Class<?> parameterType = parameterTypes[i];
+            arguments[i] = getSetupArgumentForParameterType(i, parameterType, parameterAnnotations[i]);
+        }
+        return arguments;
+    }
+
+    private Object getSetupArgumentForParameterType(int index, Class<?> parameterType, Annotation[] parameterAnnotations) {
+        if (parameterType.equals(IntervalProbe.class)) {
+            String probeName = getProbeName(parameterAnnotations, index);
+            return getOrCreateProbe(probeName, IntervalProbe.class);
+        }
+        if (parameterType.equals(SimpleProbe.class)) {
+            String probeName = getProbeName(parameterAnnotations, index);
+            SimpleProbe probe = getOrCreateProbe(probeName, SimpleProbe.class);
+            probeMap.put(probeName, probe);
+            return probe;
+        }
+        if (parameterType.isAssignableFrom(TestContext.class)) {
+            return testContext;
+        }
+        throw new IllegalArgumentException(format("Unknown parameter type %s at index %s in setup method", parameterType, index));
     }
 
     private void injectDependencies() {
-        Field[] fields = clazz.getDeclaredFields();
+        Field[] fields = testClassType.getDeclaredFields();
         for (Field field : fields) {
             String name = getProbeName(field);
             if (SimpleProbe.class.equals(field.getType())) {
                 SimpleProbe probe = getOrCreateProbe(name, SimpleProbe.class);
-                injectObjectToTest(field, probe);
+                injectObjectToInstance(testClassInstance, field, probe);
             } else if (IntervalProbe.class.equals(field.getType())) {
                 IntervalProbe probe = getOrCreateProbe(name, IntervalProbe.class);
-                injectObjectToTest(field, probe);
+                injectObjectToInstance(testClassInstance, field, probe);
             }
         }
+    }
+
+    private String getProbeName(Annotation[] parameterType, int index) {
+        for (Annotation annotation : parameterType) {
+            if (annotation.annotationType().equals(Name.class)) {
+                Name name = (Name) annotation;
+                return name.value();
+            }
+        }
+        return "Probe" + index;
     }
 
     private String getProbeName(Field field) {
@@ -216,345 +279,19 @@ public class TestContainer<T extends TestContext> {
         return field.getName();
     }
 
-    private void injectObjectToTest(Field field, Object object) {
-        field.setAccessible(true);
-        try {
-            field.set(testObject, object);
-        } catch (IllegalAccessException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    private void initSetupArguments(Method method) {
-        Class<?>[] parameterTypes = method.getParameterTypes();
-        Annotation[][] parameterAnnotations = method.getParameterAnnotations();
-        setupArguments = new Object[parameterTypes.length];
-        for (int i = 0; i < parameterTypes.length; i++) {
-            Class<?> parameterType = parameterTypes[i];
-            initSetupArgument(i, parameterType, parameterAnnotations[i]);
-        }
-    }
-
-    private void initSetupArgument(int i, Class<?> parameterType, Annotation[] parameterAnnotations) {
-        if (parameterType.equals(IntervalProbe.class)) {
-            String probeName = getProbeName(parameterAnnotations, i);
-            IntervalProbe probe = getOrCreateProbe(probeName, IntervalProbe.class);
-            setupArguments[i] = probe;
-        } else if (parameterType.equals(SimpleProbe.class)) {
-            String probeName = getProbeName(parameterAnnotations, i);
-            SimpleProbe probe = getOrCreateProbe(probeName, SimpleProbe.class);
-            probeMap.put(probeName, probe);
-            setupArguments[i] = probe;
-        } else if (parameterType.isAssignableFrom(TestContext.class)) {
-            setupArguments[i] = testContext;
-        }
-    }
-
-    private <T extends SimpleProbe> T getOrCreateProbe(String probeName, Class<T> probeType) {
+    @SuppressWarnings("unchecked")
+    private <P extends SimpleProbe> P getOrCreateProbe(String probeName, Class<P> probeType) {
         SimpleProbe<?, ?> probe = probeMap.get(probeName);
         if (probe == null) {
             probe = Probes.createProbe(probeType, probeName, probesConfiguration);
             probeMap.put(probeName, probe);
-            return (T) probe;
+            return (P) probe;
         }
         if (probeType.isAssignableFrom(probe.getClass())) {
-            return (T) probe;
+            return (P) probe;
         }
-        throw new IllegalArgumentException("Can't create a probe " + probeName + " of type " + probeType.getName() + " as " +
-                "there is already a probe " + probe.getClass() + " with the same name");
-
-    }
-
-    private String getProbeName(Annotation[] parameterType, int i) {
-        for (Annotation annotation : parameterType) {
-            if (annotation.annotationType().equals(Name.class)) {
-                Name name = (Name) annotation;
-                return name.value();
-            }
-        }
-        return "Probe" + i;
-    }
-
-    private void initGetOperationCountMethod() {
-        List<Method> methods = findMethod(Performance.class);
-        assertAtMostOne(methods, Performance.class);
-
-        if (methods.isEmpty()) {
-            return;
-        }
-
-        Method method = methods.get(0);
-        method.setAccessible(true);
-        assertNotStatic(method);
-        assertNoArgs(method);
-        assertReturnType(method, Long.TYPE);
-        operationCountMethod = method;
-    }
-
-    private void initRunMethod() {
-        List<Method> methods = findMethod(Run.class);
-        assertExactlyOne(methods, Run.class);
-
-        Method method = methods.get(0);
-        method.setAccessible(true);
-        assertVoidReturnType(method);
-        assertNotStatic(method);
-        assertNoArgs(method);
-        runMethod = method;
-    }
-
-    private void initLocalVerifyMethod() {
-        List<Method> methods = findMethod(Verify.class, new Filter<Verify>() {
-            @Override
-            public boolean allowed(Verify t) {
-                return !t.global();
-            }
-        });
-
-        if (methods.isEmpty()) {
-            return;
-        }
-
-        assertAtMostOne(methods, Verify.class);
-        Method method = methods.get(0);
-        method.setAccessible(true);
-        assertVoidReturnType(method);
-        assertNotStatic(method);
-        assertNoArgs(method);
-        localVerifyMethod = method;
-    }
-
-    private void initGlobalVerifyMethod() {
-        List<Method> methods = findMethod(Verify.class, new Filter<Verify>() {
-            @Override
-            public boolean allowed(Verify t) {
-                return t.global();
-            }
-        });
-
-        if (methods.isEmpty()) {
-            return;
-        }
-
-        assertAtMostOne(methods, Verify.class);
-        Method method = methods.get(0);
-        method.setAccessible(true);
-        assertVoidReturnType(method);
-        assertNotStatic(method);
-        assertNoArgs(method);
-        globalVerifyMethod = method;
-    }
-
-    private void initLocalTeardownMethod() {
-        List<Method> methods = findMethod(Teardown.class, new Filter<Teardown>() {
-            @Override
-            public boolean allowed(Teardown t) {
-                return !t.global();
-            }
-        });
-
-        if (methods.isEmpty()) {
-            return;
-        }
-
-        assertAtMostOne(methods, Teardown.class);
-        Method method = methods.get(0);
-        method.setAccessible(true);
-        assertVoidReturnType(method);
-        assertNotStatic(method);
-        assertNoArgs(method);
-        localTeardownMethod = method;
-    }
-
-    private void initGlobalTeardownMethod() {
-        List<Method> methods = findMethod(Teardown.class, new Filter<Teardown>() {
-            @Override
-            public boolean allowed(Teardown t) {
-                return t.global();
-            }
-        });
-
-        if (methods.isEmpty()) {
-            return;
-        }
-
-        assertAtMostOne(methods, Teardown.class);
-        Method method = methods.get(0);
-        method.setAccessible(true);
-        assertVoidReturnType(method);
-        assertNotStatic(method);
-        assertNoArgs(method);
-        globalTeardownMethod = method;
-    }
-
-    private void initLocalWarmupMethod() {
-        List<Method> methods = findMethod(Warmup.class, new Filter<Warmup>() {
-            @Override
-            public boolean allowed(Warmup t) {
-                return !t.global();
-            }
-        });
-
-        if (methods.isEmpty()) {
-            return;
-        }
-
-        assertAtMostOne(methods, Warmup.class);
-        Method method = methods.get(0);
-        method.setAccessible(true);
-        assertVoidReturnType(method);
-        assertNotStatic(method);
-        assertNoArgs(method);
-        localWarmupMethod = method;
-    }
-
-    private void initGlobalWarmupMethod() {
-        List<Method> methods = findMethod(Warmup.class, new Filter<Warmup>() {
-            @Override
-            public boolean allowed(Warmup t) {
-                return t.global();
-            }
-        });
-
-        if (methods.isEmpty()) {
-            return;
-        }
-
-        assertAtMostOne(methods, Warmup.class);
-        Method method = methods.get(0);
-        method.setAccessible(true);
-        assertVoidReturnType(method);
-        assertNotStatic(method);
-        assertNoArgs(method);
-        globalWarmupMethod = method;
-    }
-
-    private void initMessageConsumerMethod() {
-        List<Method> methods = findMethod(Receive.class);
-        if (methods.isEmpty()) {
-            return;
-        }
-
-        assertAtMostOne(methods, Receive.class);
-        Method method = methods.get(0);
-        method.setAccessible(true);
-        assertVoidReturnType(method);
-        assertNotStatic(method);
-        assertArguments(method, Message.class);
-        messageConsumerMethod = method;
-
-    }
-
-    private void assertNotStatic(Method method) {
-        if (Modifier.isStatic(method.getModifiers())) {
-            throw new IllegalTestException(
-                    format("Method  %s can't be static", method.getName()));
-
-        }
-    }
-
-    private void assertNoArgs(Method method) {
-        if (method.getParameterTypes().length == 0) {
-            return;
-        }
-
-        throw new IllegalTestException(format("Method '%s' can't have any args", method));
-    }
-
-    private void assertSetupArguments(Method method) {
-        Class<?>[] parameterTypes = method.getParameterTypes();
-        if (parameterTypes.length < 1) {
-            return;
-        }
-
-        boolean testContextFound = false;
-        for (Class<?> parameterType : parameterTypes) {
-            if (parameterType.isAssignableFrom(TestContext.class)) {
-                testContextFound = true;
-            } else if (!parameterType.isAssignableFrom(IntervalProbe.class)) {
-                throw new IllegalTestException("Method " + clazz + "." + method + " must have argument of type "
-                        + TestContext.class + " and zero or more arguments of type " + SimpleProbe.class);
-            }
-        }
-        if (!testContextFound) {
-            throw new IllegalTestException("Method " + clazz + "." + method + " must have argument of type " + TestContext.class
-                    + " and zero or more arguments of type " + SimpleProbe.class);
-        }
-    }
-
-    private void assertArguments(Method method, Class<?>... arguments) {
-        Class<?>[] parameterTypes = method.getParameterTypes();
-        if (parameterTypes.length != arguments.length) {
-            throw new IllegalTestException(
-                    format("Method %s must have %s arguments, but %s arguments found",
-                            method, arguments.length, parameterTypes.length));
-        }
-
-        for (int i = 0; i < arguments.length; i++) {
-            if (!parameterTypes[i].isAssignableFrom(arguments[i])) {
-                throw new IllegalTestException(
-                        format("Method %s has %s. argument of type %s where type %s is expected",
-                                method, i + 1, parameterTypes[i], arguments[i]));
-            }
-        }
-    }
-
-    private void assertExactlyOne(List<Method> methods, Class<? extends Annotation> annotation) {
-        if (methods.size() == 0) {
-            throw new IllegalTestException(
-                    format("No method annotated with %s found on class %s", annotation.getName(), clazz.getName()));
-        } else if (methods.size() == 1) {
-            return;
-        } else {
-            throw new IllegalTestException(
-                    format("Too many methods on class %s with annotation %s", clazz.getName(), annotation.getName()));
-        }
-    }
-
-    private void assertAtMostOne(List<Method> methods, Class<? extends Annotation> annotation) {
-        if (methods.size() > 1) {
-            throw new IllegalTestException(
-                    format("Too many methods on class %s with annotation %s", clazz.getName(), annotation.getName()));
-        }
-    }
-
-    private void assertVoidReturnType(Method method) {
-        assertReturnType(method, Void.TYPE);
-    }
-
-    private void assertReturnType(Method method, Class expectedType) {
-        if (expectedType.equals(method.getReturnType())) {
-            return;
-        }
-
-        throw new IllegalTestException("Method " + clazz + "." + method + " should have returnType: " + expectedType);
-    }
-
-    private List<Method> findMethod(Class<? extends Annotation> annotation) {
-        return findMethod(annotation, new AlwaysFilter());
-    }
-
-    private List<Method> findMethod(Class<? extends Annotation> annotation, Filter filter) {
-        List<Method> methods = new LinkedList<Method>();
-
-        for (Method method : clazz.getDeclaredMethods()) {
-            Annotation found = method.getAnnotation(annotation);
-            if (found != null && filter.allowed(found)) {
-                methods.add(method);
-            }
-        }
-
-        return methods;
-    }
-
-    private interface Filter<A extends Annotation> {
-        boolean allowed(A m);
-    }
-
-    private class AlwaysFilter implements Filter {
-        @Override
-        public boolean allowed(Annotation m) {
-            return true;
-        }
+        throw new IllegalArgumentException(
+                format("Can't create a probe %s of type %s as there is already a probe %s with the same name", probeName,
+                        probeType.getName(), probe.getClass()));
     }
 }

--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/worker/utils/AnnotationFilter.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/worker/utils/AnnotationFilter.java
@@ -1,0 +1,62 @@
+package com.hazelcast.stabilizer.worker.utils;
+
+import com.hazelcast.stabilizer.test.annotations.Teardown;
+import com.hazelcast.stabilizer.test.annotations.Verify;
+import com.hazelcast.stabilizer.test.annotations.Warmup;
+
+import java.lang.annotation.Annotation;
+
+/**
+ * This class filters Annotations, e.g. after their values.
+ *
+ * @param <A>    Class of type Annotation
+ */
+public interface AnnotationFilter<A extends Annotation> {
+    boolean allowed(A annotation);
+
+    public static class AlwaysFilter implements AnnotationFilter<Annotation> {
+        @Override
+        public boolean allowed(Annotation annotation) {
+            return true;
+        }
+    }
+
+    public class TeardownFilter implements AnnotationFilter<Teardown> {
+        private final boolean isGlobal;
+
+        public TeardownFilter(boolean isGlobal) {
+            this.isGlobal = isGlobal;
+        }
+
+        @Override
+        public boolean allowed(Teardown teardown) {
+            return teardown.global() == isGlobal;
+        }
+    }
+
+    public class WarmupFilter implements AnnotationFilter<Warmup> {
+        private final boolean isGlobal;
+
+        public WarmupFilter(boolean isGlobal) {
+            this.isGlobal = isGlobal;
+        }
+
+        @Override
+        public boolean allowed(Warmup verify) {
+            return verify.global() == isGlobal;
+        }
+    }
+
+    public class VerifyFilter implements AnnotationFilter<Verify> {
+        private final boolean isGlobal;
+
+        public VerifyFilter(boolean isGlobal) {
+            this.isGlobal = isGlobal;
+        }
+
+        @Override
+        public boolean allowed(Verify verify) {
+            return verify.global() == isGlobal;
+        }
+    }
+}

--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/worker/utils/ReflectionUtils.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/worker/utils/ReflectionUtils.java
@@ -1,0 +1,199 @@
+package com.hazelcast.stabilizer.worker.utils;
+
+import com.hazelcast.stabilizer.test.exceptions.IllegalTestException;
+import com.hazelcast.stabilizer.worker.utils.AnnotationFilter.AlwaysFilter;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.LinkedList;
+import java.util.List;
+
+import static java.lang.String.format;
+
+public class ReflectionUtils {
+
+    private ReflectionUtils() {
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <E> E invokeMethod(Object classInstance, Method method, Object... args) throws Throwable {
+        if (method == null) {
+            return null;
+        }
+
+        try {
+            return (E) method.invoke(classInstance, args);
+        } catch (InvocationTargetException e) {
+            throw e.getCause();
+        }
+    }
+
+    public static void injectObjectToInstance(Object classInstance, Field field, Object object) {
+        field.setAccessible(true);
+        try {
+            field.set(classInstance, object);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static Method getMandatoryVoidMethodWithoutArgs(Class classType, Class<? extends Annotation> annotationType) {
+        List<Method> methods = findMethod(classType, annotationType);
+        assertExactlyOne(methods, classType, annotationType);
+
+        Method method = methods.get(0);
+        method.setAccessible(true);
+        assertNotStatic(method);
+        assertVoidReturnType(classType, method);
+        assertNoArgs(method);
+
+        return method;
+    }
+
+    public static Method getOptionalVoidMethodSkipArgsCheck(Class<?> classType, Class<? extends Annotation> annotationType) {
+        return getOptionalAnnotationMethod(classType, annotationType, new AlwaysFilter(), null, true);
+    }
+
+    public static Method getOptionalVoidMethodWithoutArgs(Class<?> classType, Class<? extends Annotation> annotationType,
+                                                          AnnotationFilter filter) {
+        return getOptionalAnnotationMethod(classType, annotationType, filter, null, false);
+    }
+
+    public static Method getOptionalMethodWithoutArgs(Class<?> classType, Class<? extends Annotation> annotationType,
+                                                      Class returnType) {
+        return getOptionalAnnotationMethod(classType, annotationType, new AlwaysFilter(), returnType, false);
+    }
+
+    /**
+     * Searches for an optional method of the given annotation.
+     *
+     * @param classType      Class to scan
+     * @param annotation     Type of the annotation
+     * @param filter         Filter to filter by annotation values
+     * @param returnType     Assert the return type of the method, use <tt>null</tt> for void methods
+     * @param skipArgsCheck  set <tt>true</tt> if assertNoArgs should be skipped
+     * @return the found method or <tt>null</tt> if no method was found
+     */
+    public static Method getOptionalAnnotationMethod(Class<?> classType, Class<? extends Annotation> annotation,
+                                                     AnnotationFilter filter, Class returnType, boolean skipArgsCheck) {
+        List<Method> methods = findMethod(classType, annotation, filter);
+        assertAtMostOne(methods, classType, annotation);
+        if (methods.isEmpty()) {
+            return null;
+        }
+
+        Method method = methods.get(0);
+        method.setAccessible(true);
+        assertNotStatic(method);
+        if (returnType == null) {
+            assertVoidReturnType(classType, method);
+        } else {
+            assertReturnType(classType, method, returnType);
+        }
+        if (!skipArgsCheck) {
+            assertNoArgs(method);
+        }
+
+        return method;
+    }
+
+    /**
+     * Returns a list of annotated methods in a class hierarchy.
+     * <p/>
+     * Returns more than one method only if they are declared in the same class.
+     * As soon as at least one method has been found, no super class will be searched.
+     * So a child class will always overwrite the annotated methods from its superclass.
+     *
+     * @param annotation Type of the annotation to search for
+     * @return List of found methods with this annotation
+     */
+    private static List<Method> findMethod(Class<?> classType, Class<? extends Annotation> annotation) {
+        return findMethod(classType, annotation, new AlwaysFilter());
+    }
+
+    /**
+     * Returns a list of annotated methods in a class hierarchy.
+     * <p/>
+     * Returns more than one method only if they are declared in the same class.
+     * As soon as at least one method has been found, no super class will be searched.
+     * So a child class will always overwrite the annotated methods from its superclass.
+     *
+     * @param annotation Type of the annotation to search for
+     * @param filter     Filter to filter search result by annotation values
+     * @return List of found methods with this annotation
+     */
+    private static List<Method> findMethod(Class<?> classType, Class<? extends Annotation> annotation, AnnotationFilter filter) {
+        List<Method> methods = new LinkedList<Method>();
+
+        // search in base class
+        findMethod(classType, annotation, filter, methods);
+
+        Class<?> searchClass = classType;
+        while (methods.size() == 0 && searchClass.getSuperclass() != null) {
+            // search in super class
+            searchClass = searchClass.getSuperclass();
+            findMethod(searchClass, annotation, filter, methods);
+        }
+
+        return methods;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void findMethod(Class<?> searchClass, Class<? extends Annotation> annotation, AnnotationFilter filter,
+                                   List<Method> methods) {
+        for (Method method : searchClass.getDeclaredMethods()) {
+            Annotation found = method.getAnnotation(annotation);
+            if (found != null && filter.allowed(found)) {
+                methods.add(method);
+            }
+        }
+    }
+
+    private static void assertExactlyOne(List<Method> methods, Class<?> classType, Class<? extends Annotation> annotation) {
+        if (methods.size() == 0) {
+            throw new IllegalTestException(
+                    format("No method on class %s with annotated %s found", classType.getName(), annotation.getName()));
+        }
+        if (methods.size() == 1) {
+            return;
+        }
+        throw new IllegalTestException(
+                format("Too many methods on class %s with annotation %s", classType.getName(), annotation.getName()));
+    }
+
+    private static void assertAtMostOne(List<Method> methods, Class<?> classType, Class<? extends Annotation> annotation) {
+        if (methods.size() > 1) {
+            throw new IllegalTestException(
+                    format("Too many methods on class %s with annotation %s", classType.getName(), annotation.getName()));
+        }
+    }
+
+    private static void assertNotStatic(Method method) {
+        if (Modifier.isStatic(method.getModifiers())) {
+            throw new IllegalTestException(format("Method  %s can't be static", method.getName()));
+        }
+    }
+
+    private static void assertVoidReturnType(Class<?> classType, Method method) {
+        assertReturnType(classType, method, Void.TYPE);
+    }
+
+    private static void assertReturnType(Class<?> classType, Method method, Class returnType) {
+        if (returnType.equals(method.getReturnType())) {
+            return;
+        }
+
+        throw new IllegalTestException("Method " + classType + "." + method + " should have returnType: " + returnType);
+    }
+
+    private static void assertNoArgs(Method method) {
+        if (method.getParameterTypes().length == 0) {
+            return;
+        }
+
+        throw new IllegalTestException(format("Method '%s' can't have any args", method));
+    }
+}

--- a/stabilizer/src/test/java/com/hazelcast/stabilizer/worker/TestContainerTest.java
+++ b/stabilizer/src/test/java/com/hazelcast/stabilizer/worker/TestContainerTest.java
@@ -6,6 +6,8 @@ import com.hazelcast.stabilizer.probes.probes.IntervalProbe;
 import com.hazelcast.stabilizer.probes.probes.ProbesConfiguration;
 import com.hazelcast.stabilizer.probes.probes.SimpleProbe;
 import com.hazelcast.stabilizer.probes.probes.impl.DisabledProbe;
+import com.hazelcast.stabilizer.test.annotations.Teardown;
+import com.hazelcast.stabilizer.test.annotations.Warmup;
 import com.hazelcast.stabilizer.test.exceptions.IllegalTestException;
 import com.hazelcast.stabilizer.test.TestContext;
 import com.hazelcast.stabilizer.test.annotations.Name;
@@ -14,238 +16,275 @@ import com.hazelcast.stabilizer.test.annotations.Receive;
 import com.hazelcast.stabilizer.test.annotations.Run;
 import com.hazelcast.stabilizer.test.annotations.Setup;
 import com.hazelcast.stabilizer.test.annotations.Verify;
+import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 public class TestContainerTest {
-    // =================== setup ========================
 
-    @Test
-    public void testRun() throws Throwable {
-        DummyTest dummyTest = new DummyTest();
-        TestContainer invoker = new TestContainer(dummyTest, new DummyTestContext(), new ProbesConfiguration());
-        invoker.run();
+    private DummyTestContext testContext;
+    private ProbesConfiguration probesConfiguration;
+    private TestContainer<DummyTestContext> invoker;
 
-        assertTrue(dummyTest.runCalled);
+    @Before
+    public void init() {
+        testContext = new DummyTestContext();
+        probesConfiguration = new ProbesConfiguration();
+    }
+
+    // =============================================================
+    // =================== find annotations ========================
+    // =============================================================
+
+    @Test(expected = IllegalTestException.class)
+    public void testRunAnnotationMissing() throws Throwable {
+        new TestContainer<DummyTestContext>(new MissingRunAnnotationTest(), testContext, probesConfiguration);
+    }
+
+    private static class MissingRunAnnotationTest {
     }
 
     @Test(expected = IllegalTestException.class)
-    public void runMissing() throws Throwable {
-        RunMissingTest test = new RunMissingTest();
-        new TestContainer(test, new DummyTestContext(), new ProbesConfiguration());
+    public void testDuplicateSetupAnnotation() {
+        new TestContainer<DummyTestContext>(new DuplicateSetupAnnotationTest(), testContext, probesConfiguration);
     }
 
-    static class RunMissingTest {
+    @SuppressWarnings("unused")
+    private static class DuplicateSetupAnnotationTest {
+        @Setup
+        void setup() {
+        }
 
         @Setup
-        void setup(TestContext context) {
+        void anotherSetup() {
         }
     }
 
+    @Test
+    public void testSimpleTest() throws Throwable {
+        DummyTest test = new DummyTest();
+        invoker = new TestContainer<DummyTestContext>(test, testContext, probesConfiguration);
+        invoker.run();
+
+        assertTrue(test.runCalled);
+    }
+
+    @Test
+    public void testSetupAnnotationInheritance() throws Throwable {
+        ChildWithOwnSetupMethodTest test = new ChildWithOwnSetupMethodTest();
+        invoker = new TestContainer<DummyTestContext>(test, testContext, probesConfiguration);
+        invoker.setup();
+        invoker.run();
+
+        assertTrue(test.childSetupCalled); // ChildWithOwnSetupMethodTest
+        assertFalse(test.setupCalled); // DummySetupTest
+        assertTrue(test.runCalled); // DummyTest
+    }
+
+    private static class ChildWithOwnSetupMethodTest extends DummySetupTest {
+        boolean childSetupCalled;
+
+        @Setup
+        void setup(TestContext context) {
+            this.context = context;
+            this.childSetupCalled = true;
+        }
+    }
+
+    @Test
+    public void testRunAnnotationInheritance() throws Throwable {
+        ChildWithOwnRunMethodTest test = new ChildWithOwnRunMethodTest();
+        invoker = new TestContainer<DummyTestContext>(test, testContext, probesConfiguration);
+        invoker.setup();
+        invoker.run();
+
+        assertTrue(test.childRunCalled); // ChildWithOwnRunMethodTest
+        assertTrue(test.setupCalled); // DummySetupTest
+        assertFalse(test.runCalled); // DummyTest
+    }
+
+    private static class ChildWithOwnRunMethodTest extends DummySetupTest {
+        boolean childRunCalled;
+
+        @Run
+        void run() {
+            this.childRunCalled = true;
+        }
+    }
+
+    // ================================================
+    // =================== run ========================
+    // ================================================
+
+    @Test
+    public void testRun() throws Throwable {
+        DummyTest test = new DummyTest();
+        invoker = new TestContainer<DummyTestContext>(test, testContext, probesConfiguration);
+        invoker.run();
+
+        assertTrue(test.runCalled);
+    }
+
+    // ==================================================
     // =================== setup ========================
+    // ==================================================
+
+    @Test()
+    public void testSetupWithoutArguments() throws Throwable {
+        new TestContainer<DummyTestContext>(new SetupWithoutArgumentsTest(), testContext, probesConfiguration);
+    }
+
+    @SuppressWarnings("unused")
+    private static class SetupWithoutArgumentsTest extends DummyTest {
+        @Setup
+        void setup() {
+        }
+    }
+
+    @Test()
+    public void testSetupWithTestContextOnly() throws Throwable {
+        new TestContainer<DummyTestContext>(new SetupWithTextContextOnlyTest(), testContext, probesConfiguration);
+    }
+
+    @SuppressWarnings("unused")
+    private static class SetupWithTextContextOnlyTest extends DummyTest {
+        @Setup
+        void setup(TestContext testContext) {
+        }
+    }
+
+    @Test(expected = IllegalTestException.class)
+    public void testSetupWithSimpleProbeOnly() throws Throwable {
+        new TestContainer<DummyTestContext>(new SetupWithSimpleProbeOnly(), testContext, probesConfiguration);
+    }
+
+    @SuppressWarnings("unused")
+    private static class SetupWithSimpleProbeOnly extends DummyTest {
+        @Setup
+        void setup(SimpleProbe simpleProbe) {
+        }
+    }
+
+    @Test(expected = IllegalTestException.class)
+    public void testIllegalSetupArguments() throws Throwable {
+        new TestContainer<DummyTestContext>(new IllegalSetupArgumentsTest(), testContext, probesConfiguration);
+    }
+
+    @SuppressWarnings("unused")
+    private static class IllegalSetupArgumentsTest extends DummyTest {
+        @Setup
+        void setup(TestContext testContext, Object wrongType) {
+        }
+    }
+
+    @Test
+    public void testSetupWithValidArguments() throws Throwable {
+        new TestContainer<DummyTestContext>(new SetupWithValidArgumentsTest(), testContext, probesConfiguration);
+    }
+
+    @SuppressWarnings("unused")
+    private static class SetupWithValidArgumentsTest extends DummyTest {
+        @Setup
+        void setup(TestContext testContext, SimpleProbe simpleProbe, IntervalProbe intervalProbe) {
+        }
+    }
 
     @Test
     public void testSetup() throws Throwable {
-        DummyTestContext testContext = new DummyTestContext();
-        DummyTest test = new DummyTest();
-        TestContainer invoker = new TestContainer(test, testContext, new ProbesConfiguration());
-        invoker.run();
+        DummySetupTest test = new DummySetupTest();
+        invoker = new TestContainer<DummyTestContext>(test, testContext, probesConfiguration);
         invoker.setup();
 
         assertTrue(test.setupCalled);
         assertSame(testContext, test.context);
+        assertFalse(test.runCalled);
     }
 
-    // =================== local verify ========================
+    // ===================================================
+    // =================== probes ========================
+    // ===================================================
 
     @Test
-    public void localVerify() throws Throwable {
-        DummyTestContext testContext = new DummyTestContext();
-        LocalVerifyTest test = new LocalVerifyTest();
-        TestContainer invoker = new TestContainer(test, testContext, new ProbesConfiguration());
-        invoker.localVerify();
-
-        assertTrue(test.localVerifyCalled);
-    }
-
-    @Test
-    public void localProbeInjected() throws Throwable {
-        DummyTestContext testContext = new DummyTestContext();
-        DummyTest test = new DummyTest();
-        TestContainer invoker = new TestContainer(test, testContext, new ProbesConfiguration());
+    public void testLocalProbeInjected() throws Throwable {
+        ProbeTest test = new ProbeTest();
+        invoker = new TestContainer<DummyTestContext>(test, testContext, probesConfiguration);
         invoker.setup();
 
         assertNotNull(test.simpleProbe);
     }
 
     @Test
-    public void probe_explicit_name_set_via_annotation() throws Throwable {
-        DummyTestContext testContext = new DummyTestContext();
-        DummyTest test = new DummyTest();
-        ProbesConfiguration probesConfig = new ProbesConfiguration();
-        probesConfig.addConfig("explicitProbeName", "throughput");
-        TestContainer invoker = new TestContainer(test, testContext, probesConfig);
+    public void testProbeExplicitNameSetViaAnnotation() throws Throwable {
+        ProbeTest test = new ProbeTest();
+        probesConfiguration.addConfig("explicitProbeName", "throughput");
+        invoker = new TestContainer<DummyTestContext>(test, testContext, probesConfiguration);
         Map probeResults = invoker.getProbeResults();
+
         assertTrue(probeResults.keySet().contains("explicitProbeName"));
     }
 
     @Test
-    public void probe_implicit_name() throws Throwable {
-        DummyTestContext testContext = new DummyTestContext();
-        DummyTest test = new DummyTest();
-        ProbesConfiguration probesConfig = new ProbesConfiguration();
-        probesConfig.addConfig("Probe2", "throughput");
-        TestContainer invoker = new TestContainer(test, testContext, probesConfig);
+    public void testProbeImplicitName() throws Throwable {
+        ProbeTest test = new ProbeTest();
+        probesConfiguration.addConfig("Probe2", "throughput");
+        invoker = new TestContainer<DummyTestContext>(test, testContext, probesConfiguration);
         Map probeResults = invoker.getProbeResults();
+
         assertTrue(probeResults.keySet().contains("Probe2"));
     }
 
     @Test
-    public void probe_inject_simpleProbe_to_field() {
-        DummyTestContext testContext = new DummyTestContext();
-        DummyTest test = new DummyTest();
-        ProbesConfiguration probesConfig = new ProbesConfiguration();
-        probesConfig.addConfig("throughputProbe", "throughput");
-        TestContainer invoker = new TestContainer(test, testContext, probesConfig);
+    public void testProbeInjectSimpleProbeToField() {
+        ProbeTest test = new ProbeTest();
+        probesConfiguration.addConfig("throughputProbe", "throughput");
+        invoker = new TestContainer<DummyTestContext>(test, testContext, probesConfiguration);
         Map probeResults = invoker.getProbeResults();
+
         assertNotNull(test.throughputProbe);
         assertTrue(probeResults.keySet().contains("throughputProbe"));
     }
 
     @Test
-         public void probe_inject_IntervalProbe_to_field() {
-        DummyTestContext testContext = new DummyTestContext();
-        DummyTest test = new DummyTest();
-        ProbesConfiguration probesConfig = new ProbesConfiguration();
-        probesConfig.addConfig("latencyProbe", "latency");
-        TestContainer invoker = new TestContainer(test, testContext, probesConfig);
+    public void testProbeInjectIntervalProbeToField() {
+        ProbeTest test = new ProbeTest();
+        probesConfiguration.addConfig("latencyProbe", "latency");
+        invoker = new TestContainer<DummyTestContext>(test, testContext, probesConfiguration);
         Map probeResults = invoker.getProbeResults();
+
         assertNotNull(test.latencyProbe);
         assertTrue(probeResults.keySet().contains("latencyProbe"));
     }
 
     @Test
-    public void probe_inject_explicitly_named_probe_to_field() {
-        DummyTestContext testContext = new DummyTestContext();
-        DummyTest test = new DummyTest();
-        ProbesConfiguration probesConfig = new ProbesConfiguration();
-        probesConfig.addConfig("explicitProbeInjectedToField", "throughput");
-        TestContainer invoker = new TestContainer(test, testContext, probesConfig);
+    public void testProbeInjectExplicitlyNamedProbeToField() {
+        ProbeTest test = new ProbeTest();
+        probesConfiguration.addConfig("explicitProbeInjectedToField", "throughput");
+        invoker = new TestContainer<DummyTestContext>(test, testContext, probesConfiguration);
         Map probeResults = invoker.getProbeResults();
+
         assertNotNull(test.fooProbe);
         assertTrue(probeResults.keySet().contains("explicitProbeInjectedToField"));
     }
 
     @Test
-    public void probe_inject_disabled_to_field() {
-        DummyTestContext testContext = new DummyTestContext();
-        DummyTest test = new DummyTest();
-        ProbesConfiguration probesConfig = new ProbesConfiguration();
-        TestContainer invoker = new TestContainer(test, testContext, probesConfig);
+    public void testProbeInjectDisabledToField() {
+        ProbeTest test = new ProbeTest();
+        new TestContainer<DummyTestContext>(test, testContext, probesConfiguration);
+
         assertNotNull(test.disabled);
         assertTrue(test.disabled instanceof DisabledProbe);
     }
 
-    @Test
-    public void testMessageReceiver() throws Throwable {
-        DummyTestContext testContext = new DummyTestContext();
-        LocalVerifyTest test = new LocalVerifyTest();
-        TestContainer invoker = new TestContainer(test, testContext, new ProbesConfiguration());
-        Message message = Mockito.mock(Message.class);
-        invoker.sendMessage(message);
-
-        assertEquals(message, test.messagePassed);
-    }
-
-    static class LocalVerifyTest {
-        boolean localVerifyCalled;
-        Message messagePassed;
-
-        @Verify(global = false)
-        void verify() {
-            localVerifyCalled = true;
-        }
-
-        @Setup
-        void setup(TestContext testContext) {
-
-        }
-
-        @Run
-        void run() {
-
-        }
-
-        @Receive
-        public void receive(Message message) {
-            messagePassed = message;
-        }
-    }
-
-    // =================== global verify ========================
-
-    @Test
-    public void globalVerify() throws Throwable {
-        DummyTestContext testContext = new DummyTestContext();
-        GlobalVerifyTest test = new GlobalVerifyTest();
-        TestContainer invoker = new TestContainer(test, testContext, new ProbesConfiguration());
-        invoker.globalVerify();
-
-        assertTrue(test.globalVerifyCalled);
-    }
-
-    static class GlobalVerifyTest {
-        boolean globalVerifyCalled;
-
-        @Verify(global = true)
-        void verify() {
-            globalVerifyCalled = true;
-        }
-
-        @Setup
-        void setup(TestContext testContext) {
-
-        }
-
-        @Run
-        void run() {
-        }
-    }
-
-    // =================== performance ========================
-
-    @Test
-    public void performance() throws Throwable {
-        DummyTestContext testContext = new DummyTestContext();
-        PerformanceTest test = new PerformanceTest();
-        TestContainer invoker = new TestContainer(test, testContext, new ProbesConfiguration());
-        long count = invoker.getOperationCount();
-
-        assertEquals(20, count);
-    }
-
-    static class PerformanceTest {
-
-        @Performance
-        public long getCount() {
-            return 20;
-        }
-
-        @Run
-        void run() {
-        }
-    }
-
-    static class DummyTest {
-        boolean runCalled;
-        boolean setupCalled;
+    @SuppressWarnings("unused")
+    private static class ProbeTest extends DummyTest {
         TestContext context;
         SimpleProbe simpleProbe;
 
@@ -259,9 +298,185 @@ public class TestContainerTest {
         @Setup
         void setup(TestContext context, @Name("explicitProbeName") SimpleProbe probe1, SimpleProbe probe2) {
             this.context = context;
-            this.setupCalled = true;
             this.simpleProbe = probe1;
         }
+    }
+
+    // ===================================================
+    // =================== warmup ========================
+    // ===================================================
+
+    @Test
+    public void testLocalWarmup() throws Throwable {
+        WarmupTest test = new WarmupTest();
+        invoker = new TestContainer<DummyTestContext>(test, testContext, probesConfiguration);
+        invoker.localWarmup();
+
+        assertTrue(test.localWarmupCalled);
+        assertFalse(test.globalWarmupCalled);
+    }
+
+    @Test
+    public void testGlobalWarmup() throws Throwable {
+        WarmupTest test = new WarmupTest();
+        invoker = new TestContainer<DummyTestContext>(test, testContext, probesConfiguration);
+        invoker.globalWarmup();
+
+        assertFalse(test.localWarmupCalled);
+        assertTrue(test.globalWarmupCalled);
+    }
+
+    @SuppressWarnings("unused")
+    private static class WarmupTest extends DummyTest {
+        boolean localWarmupCalled;
+        boolean globalWarmupCalled;
+
+        @Warmup(global = false)
+        void localTeardown() {
+            localWarmupCalled = true;
+        }
+
+        @Warmup(global = true)
+        void globalTeardown() {
+            globalWarmupCalled = true;
+        }
+    }
+
+    // ===================================================
+    // =================== verify ========================
+    // ===================================================
+
+    @Test
+    public void testLocalVerify() throws Throwable {
+        VerifyTest test = new VerifyTest();
+        invoker = new TestContainer<DummyTestContext>(test, testContext, probesConfiguration);
+        invoker.localVerify();
+
+        assertTrue(test.localVerifyCalled);
+        assertFalse(test.globalVerifyCalled);
+    }
+
+    @Test
+    public void testGlobalVerify() throws Throwable {
+        VerifyTest test = new VerifyTest();
+        invoker = new TestContainer<DummyTestContext>(test, testContext, probesConfiguration);
+        invoker.globalVerify();
+
+        assertFalse(test.localVerifyCalled);
+        assertTrue(test.globalVerifyCalled);
+    }
+
+    @SuppressWarnings("unused")
+    private static class VerifyTest extends DummyTest {
+        boolean localVerifyCalled;
+        boolean globalVerifyCalled;
+
+        @Verify(global = false)
+        void localVerify() {
+            localVerifyCalled = true;
+        }
+
+        @Verify(global = true)
+        void globalVerify() {
+            globalVerifyCalled = true;
+        }
+    }
+
+    // =====================================================
+    // =================== teardown ========================
+    // =====================================================
+
+    @Test
+    public void testLocalTeardown() throws Throwable {
+        TeardownTest test = new TeardownTest();
+        invoker = new TestContainer<DummyTestContext>(test, testContext, probesConfiguration);
+        invoker.localTeardown();
+
+        assertTrue(test.localTeardownCalled);
+        assertFalse(test.globalTeardownCalled);
+    }
+
+    @Test
+    public void testGlobalTeardown() throws Throwable {
+        TeardownTest test = new TeardownTest();
+        invoker = new TestContainer<DummyTestContext>(test, testContext, probesConfiguration);
+        invoker.globalTeardown();
+
+        assertFalse(test.localTeardownCalled);
+        assertTrue(test.globalTeardownCalled);
+    }
+
+    @SuppressWarnings("unused")
+    private static class TeardownTest extends DummyTest {
+        boolean localTeardownCalled;
+        boolean globalTeardownCalled;
+
+        @Teardown(global = false)
+        void localTeardown() {
+            localTeardownCalled = true;
+        }
+
+        @Teardown(global = true)
+        void globalTeardown() {
+            globalTeardownCalled = true;
+        }
+    }
+
+    // ========================================================
+    // =================== performance ========================
+    // ========================================================
+
+    @Test
+    public void testPerformance() throws Throwable {
+        PerformanceTest test = new PerformanceTest();
+        invoker = new TestContainer<DummyTestContext>(test, testContext, probesConfiguration);
+        long count = invoker.getOperationCount();
+
+        assertEquals(20, count);
+    }
+
+    @SuppressWarnings("unused")
+    private static class PerformanceTest {
+        @Performance
+        public long getCount() {
+            return 20;
+        }
+
+        @Run
+        void run() {
+        }
+    }
+
+    // ====================================================
+    // =================== receive ========================
+    // ====================================================
+
+    @Test
+    public void testMessageReceiver() throws Throwable {
+        ReceiveTest test = new ReceiveTest();
+        invoker = new TestContainer<DummyTestContext>(test, testContext, probesConfiguration);
+        Message message = Mockito.mock(Message.class);
+        invoker.sendMessage(message);
+
+        assertEquals(message, test.messagePassed);
+    }
+
+    @SuppressWarnings("unused")
+    private static class ReceiveTest extends DummyTest {
+        Message messagePassed;
+
+        @Receive
+        public void receive(Message message) {
+            messagePassed = message;
+        }
+    }
+
+    // ==========================================================
+    // =================== dummy classes ========================
+    // ==========================================================
+
+    private static class DummyTest {
+        boolean runCalled;
 
         @Run
         void run() {
@@ -269,7 +484,18 @@ public class TestContainerTest {
         }
     }
 
-    static class DummyTestContext implements TestContext {
+    private static class DummySetupTest extends DummyTest {
+        TestContext context;
+        boolean setupCalled;
+
+        @Setup
+        void setup(TestContext context) {
+            this.context = context;
+            this.setupCalled = true;
+        }
+    }
+
+    private static class DummyTestContext implements TestContext {
         @Override
         public HazelcastInstance getTargetInstance() {
             return null;


### PR DESCRIPTION
Removed warnings from `TestContainer`. Enhanced `findMethod()` to search super classes for annotations, so we can use inheritance at all in test classes (e.g. to create a base class for `IntIntMapTest`, `StringMapTest` and follow up classes like `StringByteMapTest` etc.).