### PR TITLE
support for AWS ELB and tests using embedded  web container with hazelcast...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,9 @@
         <jsr107.api.version>1.0.0</jsr107.api.version>
         <hdr-histogram.version>2.0.1</hdr-histogram.version>
         <jgit.version>3.5.3.201412180710-r</jgit.version>
+        <tomcat.version>7.0.54</tomcat.version>
+        <jsp.api.version>2.2.1</jsp.api.version>
+        <servlet.api.version>3.0.1</servlet.api.version>
     </properties>
 
     <modules>

--- a/stabilizer/pom.xml
+++ b/stabilizer/pom.xml
@@ -141,6 +141,11 @@
             <version>1.9.5</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk</artifactId>
+            <version>1.3.21.1</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/agent/workerjvm/WorkerJvmLauncher.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/agent/workerjvm/WorkerJvmLauncher.java
@@ -195,6 +195,7 @@ public class WorkerJvmLauncher {
         args.add("-Dhazelcast.logging.type=log4j");
         args.add("-DworkerId=" + workerJvm.id);
         args.add("-DworkerMode=" + mode);
+        args.add("-DautoCreateHZInstances="+settings.autoCreateHZInstances);
         args.add("-Dlog4j.configuration=file:" + log4jFile.getAbsolutePath());
         args.add("-classpath");
         args.add(getClasspath());

--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/agent/workerjvm/WorkerJvmSettings.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/agent/workerjvm/WorkerJvmSettings.java
@@ -26,6 +26,7 @@ public class WorkerJvmSettings implements Serializable {
 
     public int memberWorkerCount;
     public int clientWorkerCount;
+    public boolean autoCreateHZInstances = true;
 
     public int workerStartupTimeout;
     public boolean refreshJvm;
@@ -49,6 +50,7 @@ public class WorkerJvmSettings implements Serializable {
         this.log4jConfig = settings.log4jConfig;
         this.memberWorkerCount = settings.memberWorkerCount;
         this.clientWorkerCount = settings.clientWorkerCount;
+        this.autoCreateHZInstances = settings.autoCreateHZInstances;
         this.workerStartupTimeout = settings.workerStartupTimeout;
         this.refreshJvm = settings.refreshJvm;
         this.javaVendor = settings.javaVendor;

--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/coordinator/CoordinatorCli.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/coordinator/CoordinatorCli.java
@@ -46,6 +46,10 @@ public class CoordinatorCli {
             "Number of Cluster Client Worker JVM's")
             .withRequiredArg().ofType(Integer.class).defaultsTo(0);
 
+    private final OptionSpec<Boolean> autoCreateHZInstancesSpec  = parser.accepts("autoCreateHzInstances",
+            "should stabilizer auto create Hazelcast Instances default to true")
+            .withRequiredArg().ofType(Boolean.class).defaultsTo(true);
+
     private final OptionSpec<Integer> dedicatedMemberMachinesSpec = parser.accepts("dedicatedMemberMachines",
             "Controls the number of dedicated member machines. For example when there are 4 machines" +
                     "and 2 servers and 9 clients, and there is 1 dedicated member machine, then " +
@@ -183,6 +187,8 @@ public class CoordinatorCli {
         workerJvmSettings.clientVmOptions = options.valueOf(clientWorkerVmOptionsSpec);
         workerJvmSettings.memberWorkerCount = options.valueOf(memberWorkerCountSpec);
         workerJvmSettings.clientWorkerCount = options.valueOf(clientWorkerCountSpec);
+        workerJvmSettings.autoCreateHZInstances = options.valueOf(autoCreateHZInstancesSpec);
+
         workerJvmSettings.workerStartupTimeout = options.valueOf(workerStartupTimeoutSpec);
         workerJvmSettings.hzConfig = loadHzConfig();
         workerJvmSettings.clientHzConfig = loadClientHzConfig();

--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/provisioner/AwsProvisioner.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/provisioner/AwsProvisioner.java
@@ -1,0 +1,340 @@
+package com.hazelcast.stabilizer.provisioner;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.PropertiesCredentials;
+import com.amazonaws.services.ec2.AmazonEC2;
+import com.amazonaws.services.ec2.AmazonEC2Client;
+import com.amazonaws.services.ec2.model.DescribeInstanceStatusRequest;
+import com.amazonaws.services.ec2.model.DescribeInstanceStatusResult;
+import com.amazonaws.services.ec2.model.DescribeInstancesRequest;
+import com.amazonaws.services.ec2.model.DescribeInstancesResult;
+import com.amazonaws.services.ec2.model.Filter;
+import com.amazonaws.services.ec2.model.Instance;
+import com.amazonaws.services.ec2.model.InstanceStatus;
+import com.amazonaws.services.ec2.model.Reservation;
+import com.amazonaws.services.ec2.model.RunInstancesRequest;
+import com.amazonaws.services.ec2.model.RunInstancesResult;
+import com.amazonaws.services.elasticloadbalancing.AmazonElasticLoadBalancingClient;
+import com.amazonaws.services.elasticloadbalancing.model.CreateLoadBalancerRequest;
+import com.amazonaws.services.elasticloadbalancing.model.CreateLoadBalancerResult;
+import com.amazonaws.services.elasticloadbalancing.model.DescribeLoadBalancersRequest;
+import com.amazonaws.services.elasticloadbalancing.model.DescribeLoadBalancersResult;
+import com.amazonaws.services.elasticloadbalancing.model.Listener;
+import com.amazonaws.services.elasticloadbalancing.model.LoadBalancerDescription;
+import com.amazonaws.services.elasticloadbalancing.model.RegisterInstancesWithLoadBalancerRequest;
+import com.amazonaws.services.elasticloadbalancing.model.RegisterInstancesWithLoadBalancerResult;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+import com.hazelcast.stabilizer.common.AgentAddress;
+import com.hazelcast.stabilizer.common.AgentsFile;
+import com.hazelcast.stabilizer.common.StabilizerProperties;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+
+import static com.hazelcast.stabilizer.Utils.appendText;
+import static com.hazelcast.stabilizer.Utils.sleepMillis;
+
+
+/*
+* An aws specific provisioning class which is using the AWS sdk to create aws instances,  and aws elastic load balance
+*
+*
+* */
+public class AwsProvisioner {
+
+    private final static ILogger log = Logger.getLogger(AwsProvisioner.class);
+
+    //AWS specific magic strings
+    public static final String AWS_RUNNING_STATE  = "running";
+    public static final String AWS_SYSTEM_STATUS_OK = "ok";
+    public static final String AWS_PUBLIC_IP_FILTER = "ip-address";
+    public static final String AWS_KET_NAME_FILTER = "key-name";
+
+
+    //the file wich will hole the public domain name of the created load balance
+    public static final String AWS_ELB_FILE_NAME = "aws-elb.txt";
+
+    private static final int SLEEPING_MS = 1000 * 30;
+    private static final int MAX_SLEEPING_ITTERATIONS = 12;
+
+
+    private AWSCredentials credentials;
+    private AmazonEC2 ec2;
+    private AmazonElasticLoadBalancingClient elb;
+
+    private StabilizerProperties props = new StabilizerProperties();
+
+
+    private final File agentsFile = new File("agents.txt");
+    private final File elbFile = new File(AWS_ELB_FILE_NAME);
+
+    private File credentialsFile;
+
+    private String securityGroup;
+
+    private String awsKeyName;
+    private String awsAmi;
+    private String awsBoxId;
+
+    private String elbProtocol;
+    private int elbPortIn;
+    private int elbPortOut;
+    private String elbAzs;
+
+
+    public AwsProvisioner() throws IOException {
+        props.init(null);
+
+        String awsCredentialsPath = props.get("AWS_CREDENTIALS", "AwsCredentials.properties");
+        credentialsFile = new File(awsCredentialsPath);
+
+        elbProtocol = props.get("ELB_PROTOCOL");
+
+        elbPortIn = Integer.parseInt(props.get("ELB_PORT_IN"));
+        elbPortOut = Integer.parseInt(props.get("ELB_PORT_OUT"));
+        elbAzs = props.get("ELB_AZS");
+
+        awsKeyName = props.get("AWS_KEY_NAME");
+        awsAmi = props.get("AWS_AMI");
+        awsBoxId = props.get("AWS_BOXID");
+        securityGroup = props.get("SECURITY_GROUP");
+
+
+        credentials = new PropertiesCredentials(credentialsFile);
+
+        ec2 = new AmazonEC2Client(credentials);
+        elb = new AmazonElasticLoadBalancingClient(credentials);
+    }
+
+
+
+    public void addAgentsToLoadBalancer(String elbName){
+
+        if( ! isBalancerAlive(elbName) ){
+            createLoadBalancer(elbName);
+        }
+
+        List<Instance> instances = getInstancesFromAgentsFile();
+
+        addInstancesToElb(elbName, instances);
+    }
+
+
+    public List<Instance> checkAgentsFileCreateInstancesIfNeeded(int totalInstancesWanted){
+        List agents = AgentsFile.load(agentsFile);
+
+        if(totalInstancesWanted <= agents.size()){
+            log.info("Currently decreasing instances is not supported");
+            return Collections.EMPTY_LIST;
+        }
+        int instanceCount= totalInstancesWanted - agents.size();
+
+        return createInstances(instanceCount);
+    }
+
+
+    public List<Instance> createInstances(int instanceCount){
+
+        RunInstancesRequest runInstancesRequest = new RunInstancesRequest();
+
+        runInstancesRequest.withImageId(awsAmi)
+                .withInstanceType(awsBoxId)
+                .withMinCount(instanceCount)
+                .withMaxCount(instanceCount)
+                .withKeyName(awsKeyName)
+                .withSecurityGroups(securityGroup);
+
+        RunInstancesResult runInstancesResult = ec2.runInstances(runInstancesRequest);
+
+        List<Instance> checkedInstances = new ArrayList();
+        List<Instance> instances = runInstancesResult.getReservation().getInstances();
+        for (Instance i : instances) {
+
+            if(waiteForInstanceStatus(i)){
+                addInstanceToAgentsFile(i);
+                checkedInstances.add(i);
+            }else{
+                log.warning("Time out Waiting for Instance Status id=" + i.getInstanceId() );
+            }
+        }
+        return checkedInstances;
+    }
+
+    public List<Instance> getInstancesFromAgentsFile(){
+
+        DescribeInstancesRequest request = new DescribeInstancesRequest();
+        List<String> ips = new ArrayList<String>();
+
+
+        List<AgentAddress> currentAgents = AgentsFile.load(agentsFile);
+
+        for(AgentAddress agent : currentAgents){
+            ips.add(agent.publicAddress);
+        }
+
+        Filter filter = new Filter(AWS_PUBLIC_IP_FILTER, ips);
+
+        DescribeInstancesResult result = ec2.describeInstances(request.withFilters(filter));
+        List<Reservation> reservations = result.getReservations();
+
+        List<Instance> foundInstances = new ArrayList();
+
+        for (Reservation reservation : reservations) {
+            List<Instance> instances = reservation.getInstances();
+            foundInstances.addAll(instances);
+
+            for (Instance instance : instances) {
+
+                log.info("found id=" + instance.getInstanceId());
+
+            }
+        }
+        return foundInstances;
+    }
+
+    public void findAwsInstanceWithKeyName(String keyName){
+
+        File found = new File("found.txt");
+
+        DescribeInstancesRequest request = new DescribeInstancesRequest();
+        List<String> keyNames = new ArrayList<String>();
+        keyNames.add(keyName);
+
+        Filter filter = new Filter(AWS_KET_NAME_FILTER, keyNames);
+
+        DescribeInstancesResult result = ec2.describeInstances(request.withFilters(filter));
+        List<Reservation> reservations = result.getReservations();
+
+        List<Instance> foundInstances = new ArrayList();
+
+        for (Reservation reservation : reservations) {
+            List<Instance> instances = reservation.getInstances();
+            foundInstances.addAll(instances);
+
+            for (Instance i : instances) {
+                appendText(i.getPublicIpAddress() + "," + i.getPrivateIpAddress() + "\n", found);
+            }
+        }
+    }
+
+    public boolean waiteForInstanceStatus(Instance i){
+
+        DescribeInstanceStatusRequest describeStatusRequest = new DescribeInstanceStatusRequest().withInstanceIds(i.getInstanceId());
+        int counter=0;
+        while ( counter++ < MAX_SLEEPING_ITTERATIONS ) {
+            sleepMillis(SLEEPING_MS);
+
+            DescribeInstanceStatusResult statusRes = ec2.describeInstanceStatus(describeStatusRequest);
+            List<InstanceStatus> statusList = statusRes.getInstanceStatuses();
+
+            for ( InstanceStatus s : statusList ) {
+                String systemStatus = s.getSystemStatus().getStatus();
+                if(systemStatus.equals(statusList)){
+                    return true;
+                }
+            }
+        }
+
+
+        /*
+        DescribeInstancesRequest describeInstancesRequest = new DescribeInstancesRequest().withInstanceIds(i.getInstanceId());
+        int counter=0;
+        while ( counter++ < MAX_SLEEPING_ITTERATIONS ) {
+            sleepMillis(SLEEPING_MS);
+
+            DescribeInstancesResult result = ec2.describeInstances(describeInstancesRequest);
+
+            for ( Reservation r : result.getReservations() ) {
+                for ( Instance j : r.getInstances() ) {
+
+                    log.warning("Time out Waiting for Instance Status id=" + j.getInstanceId() + " " + j.getPublicIpAddress() + ", " + j.getState().getName());
+                    if ( j.getPublicIpAddress() != null  && j.getState().getName().equals(AWS_RUNNING_STATUS) ) {
+
+                        return true;
+                    }
+                }
+            }
+        }
+        */
+
+        return false;
+    }
+
+    public void addInstanceToAgentsFile(Instance i){
+        DescribeInstancesRequest describeInstancesRequest = new DescribeInstancesRequest().withInstanceIds(i.getInstanceId());
+        DescribeInstancesResult result = ec2.describeInstances(describeInstancesRequest);
+
+        for(Reservation r : result.getReservations() ){
+            for(Instance j : r.getInstances() ){
+                appendText(j.getPublicIpAddress() + "," + j.getPrivateIpAddress() + "\n", agentsFile);
+            }
+        }
+    }
+
+    public String createLoadBalancer(String name){
+
+        CreateLoadBalancerRequest lbRequest = new CreateLoadBalancerRequest();
+        lbRequest.setLoadBalancerName(name);
+        lbRequest.withAvailabilityZones(elbAzs.split(","));
+
+        List<Listener> listeners = new ArrayList();
+        listeners.add(new Listener(elbProtocol, elbPortIn, elbPortOut));
+        lbRequest.setListeners(listeners);
+
+        CreateLoadBalancerResult lbResult=elb.createLoadBalancer(lbRequest);
+        lbResult.getDNSName();
+        appendText(lbResult.getDNSName() + "\n", elbFile);
+
+        return lbRequest.getLoadBalancerName();
+    }
+
+    public boolean isBalancerAlive(String name){
+
+        Collection<String> names = new HashSet();
+        names.add(name);
+
+        DescribeLoadBalancersRequest describe = new DescribeLoadBalancersRequest();
+        describe.setLoadBalancerNames(names);
+
+        try{
+            DescribeLoadBalancersResult res=  elb.describeLoadBalancers(describe);
+            List<LoadBalancerDescription> description = res.getLoadBalancerDescriptions();
+
+            if(description.isEmpty()){
+                return false;
+            }
+
+            return true;
+
+        }catch (AmazonServiceException e) {
+            log.warning(e);
+        }
+        return false;
+    }
+
+    public void addInstancesToElb(String name, List<Instance> instances){
+        if(instances.isEmpty()){
+            log.info("No instances to add to load balance "+name);
+            return;
+        }
+
+        //get instance id's
+        Collection ids = new ArrayList();
+        for (Instance i: instances) {
+            ids.add(new com.amazonaws.services.elasticloadbalancing.model.Instance(i.getInstanceId()));
+        }
+
+        //register the instances to the balancer
+        RegisterInstancesWithLoadBalancerRequest register = new RegisterInstancesWithLoadBalancerRequest();
+        register.setLoadBalancerName(name);
+        register.setInstances(ids);
+        RegisterInstancesWithLoadBalancerResult registerWithLoadBalancerResult = elb.registerInstancesWithLoadBalancer(register);
+    }
+}

--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/provisioner/HazelcastJars.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/provisioner/HazelcastJars.java
@@ -57,6 +57,7 @@ public class HazelcastJars {
             } else {
                 mavenRetrieve("hazelcast", version);
                 mavenRetrieve("hazelcast-client", version);
+                mavenRetrieve("hazelcast-wm", version);
             }
         } else if (versionSpec.startsWith(GIT_VERSION_PREFIX)) {
             if (eejars) {

--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/provisioner/ProvisionerCli.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/provisioner/ProvisionerCli.java
@@ -34,6 +34,20 @@ public class ProvisionerCli {
     public final OptionSpec cleanSpec = parser.accepts("clean",
             "Cleans the workers directories.");
 
+
+    public final OptionSpec<String> makeLBSpec = parser.accepts("makeLB",
+            "takes the name of a load balancer to create.  Makes an AWS load balancer with a given name, if it dose not exist (AWS only)."
+    ).withRequiredArg().ofType(String.class);
+
+    public final OptionSpec<String> agentsToLB = parser.accepts("agentsToLB",
+            "given the name of a load balancer adds the ips in Agents.txt file to the named balancer (AWS only)."
+    ).withRequiredArg().ofType(String.class);
+
+    public final OptionSpec<String> withKeySpec = parser.accepts("awsWithKey",
+            "find aws instances with key name, if jclouds times but instances are created, this utils helps to reclame them (aws only)."
+    ).withRequiredArg().ofType(String.class);;
+
+
     public final OptionSpec<Integer> scaleSpec = parser.accepts("scale",
             "Number of agent machines to scale to. If the number of machines already exists, the call is ignored. If the " +
                     "desired number of machines is smaller than the actual number of machines, machines are terminated."
@@ -107,6 +121,18 @@ public class ProvisionerCli {
             provisioner.scale(size, enterpriseEnabled);
         } else if (options.has(listAgentsSpec)) {
             provisioner.listAgents();
+        }else if (options.has(makeLBSpec)) {
+            String name = options.valueOf(makeLBSpec);
+            AwsProvisioner aws = new AwsProvisioner();
+            aws.createLoadBalancer(name);
+        }else if (options.has(agentsToLB)) {
+            String name = options.valueOf(agentsToLB);
+            AwsProvisioner aws = new AwsProvisioner();
+            aws.addAgentsToLoadBalancer(name);
+        }else if (options.has(withKeySpec)) {
+            String name = options.valueOf(withKeySpec);
+            AwsProvisioner aws = new AwsProvisioner();
+            aws.findAwsInstanceWithKeyName(name);
         } else {
             parser.printHelpOn(System.out);
         }

--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/worker/MemberWorker.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/worker/MemberWorker.java
@@ -85,8 +85,8 @@ public class MemberWorker {
     private final BlockingQueue<CommandRequest> requestQueue = new LinkedBlockingQueue<CommandRequest>();
     private final BlockingQueue<CommandResponse> responseQueue = new LinkedBlockingQueue<CommandResponse>();
 
-    private HazelcastInstance serverInstance;
-    private HazelcastInstance clientInstance;
+    private HazelcastInstance serverInstance=null;
+    private HazelcastInstance clientInstance=null;
 
     private String hzFile;
     private String clientHzFile;
@@ -94,23 +94,28 @@ public class MemberWorker {
     private String workerMode;
     private String workerId;
 
+    private boolean autoCreateHazelcastInstance=true;
+
     public void start() throws Exception {
-        if ("server".equals(workerMode)) {
+
+        if(autoCreateHazelcastInstance){
+            if ("server".equals(workerMode)) {
+                log.info("------------------------------------------------------------------------");
+                log.info("             member mode");
+                log.info("------------------------------------------------------------------------");
+                this.serverInstance = createServerHazelcastInstance();
+                TestUtils.warmupPartitions(log, serverInstance);
+            } else if ("client".equals(workerMode)) {
+                log.info("------------------------------------------------------------------------");
+                log.info("             client mode");
+                log.info("------------------------------------------------------------------------");
+                this.clientInstance = createClientHazelcastInstance();
+                TestUtils.warmupPartitions(log, clientInstance);
+            } else {
+                throw new IllegalStateException("Unknown worker mode:" + workerMode);
+            }
             log.info("------------------------------------------------------------------------");
-            log.info("             member mode");
-            log.info("------------------------------------------------------------------------");
-            this.serverInstance = createServerHazelcastInstance();
-            TestUtils.warmupPartitions(log, serverInstance);
-        } else if ("client".equals(workerMode)) {
-            log.info("------------------------------------------------------------------------");
-            log.info("             client mode");
-            log.info("------------------------------------------------------------------------");
-            this.clientInstance = createClientHazelcastInstance();
-            TestUtils.warmupPartitions(log, clientInstance);
-        } else {
-            throw new IllegalStateException("Unknown worker mode:" + workerMode);
         }
-        log.info("------------------------------------------------------------------------");
 
         workerMessageProcessor.setHazelcastServerInstance(serverInstance);
         workerMessageProcessor.setHazelcastClientInstance(clientInstance);
@@ -202,11 +207,20 @@ public class MemberWorker {
             String workerMode = System.getProperty("workerMode");
             log.info("Worker mode:" + workerMode);
 
+            String autoCreateHZInstances = System.getProperty("autoCreateHZInstances");
+            log.info("autoCreateHZInstances :" + autoCreateHZInstances);
+
+
             MemberWorker worker = new MemberWorker();
             worker.workerId = workerId;
             worker.hzFile = workerHzFile;
             worker.clientHzFile = clientHzFile;
             worker.workerMode = workerMode;
+
+            if("false".equals(autoCreateHZInstances)){
+                worker.autoCreateHazelcastInstance=false;
+            }
+
             worker.start();
 
             log.info("Successfully started Hazelcast Stabilizer Worker:" + workerId);

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -25,6 +25,11 @@
         </dependency>
         <dependency>
             <groupId>com.hazelcast</groupId>
+            <artifactId>hazelcast-wm</artifactId>
+            <version>${hazelcast.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast-client</artifactId>
             <version>${hazelcast.version}</version>
         </dependency>
@@ -34,5 +39,44 @@
             <artifactId>cache-api</artifactId>
             <version>${jsr107.api.version}</version>
         </dependency>
+
+
+
+        <dependency>
+            <groupId>javax.servlet.jsp</groupId>
+            <artifactId>javax.servlet.jsp-api</artifactId>
+            <version>${jsp.api.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>${servlet.api.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.3.1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.tomcat</groupId>
+            <artifactId>tomcat-catalina</artifactId>
+            <version>${tomcat.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.tomcat</groupId>
+            <artifactId>tomcat-util</artifactId>
+            <version>${tomcat.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.tomcat.embed</groupId>
+            <artifactId>tomcat-embed-core</artifactId>
+            <version>${tomcat.version}</version>
+        </dependency>
+
     </dependencies>
 </project>

--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/webContainer/KeyValueServlet.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/webContainer/KeyValueServlet.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2008-2014, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.stabilizer.tests.webContainer;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+import java.io.IOException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+
+/*
+* A servlet to run inside a web container.  This servlet accepts http Put and Get requests,  and implements a simple
+* key value rest service.  a http put request with a uri of "key/123/789"  will put key 123 and value 789 into the
+* session, for this user,  also the value put "789" is written back to the user.
+* A http get request with a uri of "key/123"  will get the value for key 123 from this clients session.
+* */
+public class KeyValueServlet extends HttpServlet {
+
+    Pattern getKeyPattern = Pattern.compile("key/.*");
+    Pattern putKeyPattern = Pattern.compile("key/.*/.*");
+
+    public KeyValueServlet(){
+        System.out.println("deployed "+this.getClass());
+    }
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        HttpSession session = req.getSession();
+
+        Matcher keyMatched = getKeyPattern.matcher(req.getRequestURI());
+        if (keyMatched.find()) {
+
+            String[] split = keyMatched.group().split("/");
+            String key = split[1];
+
+            Object value = session.getAttribute(key);
+
+            System.out.println("get sessionId="+session.getId()+" key="+key+" val="+value);
+
+            if(value==null){
+                resp.getWriter().write("key="+key+" Not found in session "+session.getId());
+            }
+            else{
+                resp.getWriter().write(value.toString());
+            }
+        }
+    }
+
+    @Override
+    protected void doPut(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        HttpSession session = req.getSession();
+
+        Matcher keyMatched = putKeyPattern.matcher(req.getRequestURI());
+        if (keyMatched.find()) {
+
+            String[] split = keyMatched.group().split("/");
+            String key = split[1];
+            String value = split[2];
+
+            System.out.println("put sessionId="+session.getId()+" key="+key+" val="+value);
+
+            session.setAttribute(key, value);
+            resp.getWriter().write(value.toString());
+        }
+    }
+}

--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/webContainer/ServletContainer.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/webContainer/ServletContainer.java
@@ -1,0 +1,13 @@
+package com.hazelcast.stabilizer.tests.webContainer;
+
+public interface ServletContainer {
+
+    public void restart() throws Exception;
+
+    public void stop() throws Exception;
+
+    public void start() throws Exception;
+
+    public boolean isRunning();
+
+}

--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/webContainer/TomCatContainer.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/webContainer/TomCatContainer.java
@@ -1,0 +1,66 @@
+package com.hazelcast.stabilizer.tests.webContainer;
+
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+import com.hazelcast.stabilizer.test.TestContext;
+import com.hazelcast.stabilizer.test.TestRunner;
+import com.hazelcast.stabilizer.test.annotations.Run;
+import com.hazelcast.stabilizer.test.annotations.Setup;
+import com.hazelcast.stabilizer.test.annotations.Verify;
+import com.hazelcast.stabilizer.test.annotations.Warmup;
+
+import java.util.logging.FileHandler;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.SimpleFormatter;
+
+import static com.hazelcast.stabilizer.test.utils.TestUtils.sleepMs;
+import static org.junit.Assert.assertEquals;
+
+
+/*
+* This "test" simple starts a Tomcat server instance,  which is in turn configured vai an xml file to, create an hazelcast
+* instance.  this "test" only sleeps in it's run method.  when running this sets,  we should consider,  who should take
+* responsibility for creating hazelcast instances
+* */
+public class TomCatContainer {
+
+    private final static ILogger log = Logger.getLogger(TomCatContainer.class);
+    public String basename = this.getClass().getSimpleName();
+    public int port=6555;
+    public String webAppPath="webapp";
+    public String configXml="tomcat-hz.xml";
+
+    private TomcatServer tomcat;
+    private TestContext testContext;
+
+    @Setup
+    public void setup(TestContext testContext) throws Exception {
+
+        this.testContext = testContext;
+        TomcatServer tomcat = new TomcatServer(port, webAppPath, configXml);
+    }
+
+    @Warmup(global = true)
+    public void warmup() throws Exception {
+
+    }
+
+    @Run
+    public void run() {
+        while (!testContext.isStopped()) {
+            sleepMs(2000);
+        }
+    }
+
+
+    @Verify(global = true)
+    public void verify() throws Exception {
+
+    }
+
+    public static void main(String[] args) throws Throwable {
+        TomCatContainer test = new TomCatContainer();
+        new TestRunner<TomCatContainer>(test).run();
+    }
+}

--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/webContainer/TomcatServer.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/webContainer/TomcatServer.java
@@ -1,0 +1,71 @@
+package com.hazelcast.stabilizer.tests.webContainer;
+
+import org.apache.catalina.Context;
+import org.apache.catalina.Globals;
+import org.apache.catalina.LifecycleException;
+import org.apache.catalina.startup.ContextConfig;
+import org.apache.catalina.startup.Tomcat;
+
+import java.io.File;
+import java.util.Random;
+
+public class TomcatServer implements ServletContainer {
+
+    Tomcat tomcat;
+    String serverXml;
+    String sourceDir;
+    int port;
+    volatile boolean running;
+
+    public TomcatServer(int port, String sourceDir, String serverXml) throws Exception {
+        this.port = port;
+        this.sourceDir = sourceDir;
+        this.serverXml = serverXml;
+        buildTomcat();
+    }
+
+    @Override
+    public void stop() throws Exception {
+        tomcat.stop();
+        tomcat.destroy();
+        running = false;
+    }
+
+    @Override
+    public void start() throws Exception {
+        buildTomcat();
+        running = true;
+    }
+
+    @Override
+    public void restart() throws Exception {
+        stop();
+        Thread.sleep(5000);
+        start();
+    }
+
+    private void buildTomcat() throws LifecycleException {
+        tomcat = new Tomcat();
+        tomcat.setPort(port);
+
+        String base = System.getProperty("user.home");
+        tomcat.setBaseDir(base);
+
+
+        Context context = tomcat.addContext("/", sourceDir);
+        context.getServletContext().setAttribute(Globals.ALT_DD_ATTR, base+"/webapps/"+sourceDir+"/WEB-INF/"+serverXml);
+        ContextConfig contextConfig = new ContextConfig();
+        context.addLifecycleListener(contextConfig);
+        context.setCookies(true);
+        context.setBackgroundProcessorDelay(1);
+        context.setReloadable(true);
+
+        tomcat.start();
+        running = true;
+    }
+
+    @Override
+    public boolean isRunning() {
+        return running;
+    }
+}

--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/webContainer/WebClient.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/webContainer/WebClient.java
@@ -1,0 +1,151 @@
+package com.hazelcast.stabilizer.tests.webContainer;
+
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+import com.hazelcast.stabilizer.test.TestContext;
+import com.hazelcast.stabilizer.test.annotations.Run;
+import com.hazelcast.stabilizer.test.annotations.Setup;
+import com.hazelcast.stabilizer.test.annotations.Verify;
+import com.hazelcast.stabilizer.test.annotations.Warmup;
+import com.hazelcast.stabilizer.test.utils.ThreadSpawner;
+
+
+import com.hazelcast.stabilizer.worker.OperationSelector;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.CookieStore;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.impl.client.BasicCookieStore;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.util.EntityUtils;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Random;
+
+import static org.junit.Assert.assertEquals;
+
+
+/*
+*
+* A Load producing WebClient test.  making http Put and Get requests,  the the serverIp address / port configured in the
+* properties.  each thread of this test represents a http client / "browser".
+*
+* */
+public class WebClient {
+
+    private final static ILogger log = Logger.getLogger(WebClient.class);
+
+    public String serverIp="";
+    public int serverPort=0;
+
+    public String id;
+    public int threadCount = 3;
+    public int maxKeys=1000;
+    public double getRequestProb = 0.5;
+    public double postRequestProb = 0.5;
+
+    private TestContext testContext;
+
+    private enum RequestType {
+        GET_REQUEST,
+        PUT_REQUEST
+    }
+
+    @Setup
+    public void setup(TestContext testContext) throws Exception {
+        this.testContext = testContext;
+        id = testContext.getTestId();
+
+    }
+
+    @Warmup(global = true)
+    public void warmup() throws Exception { }
+
+    @Run
+    public void run() {
+        ThreadSpawner spawner = new ThreadSpawner(testContext.getTestId());
+        for (int k = 0; k < threadCount; k++) {
+            spawner.spawn(new Worker());
+        }
+        spawner.awaitCompletion();
+    }
+
+    private class Worker implements Runnable {
+        private CookieStore cookieStore;
+        private HttpClient client;
+        private String baseRul = "http://"+serverIp+":"+serverPort+"/";
+
+        private Random random = new Random();
+        private OperationSelector<RequestType> requestSelector = new OperationSelector<RequestType>();
+
+        HashMap<Integer, String> putKeyValues = new HashMap();
+
+        public Worker(){
+            cookieStore = new BasicCookieStore();
+            client = HttpClientBuilder.create().disableRedirectHandling().setDefaultCookieStore(cookieStore).build();
+
+            log.info(id+": baseRul="+baseRul + " cookie="+cookieStore);
+
+            requestSelector.addOperation(RequestType.GET_REQUEST, getRequestProb)
+                           .addOperation(RequestType.PUT_REQUEST, postRequestProb);
+
+
+            try{
+                for(int key=0; key<maxKeys; key++){
+                    int val = random.nextInt();
+                    String res = putRequest("key/"+key+"/"+val);
+                    putKeyValues.put(key, res);
+                }
+            }catch(Exception e){throw new RuntimeException(e);}
+        }
+
+        public void run() {
+            while (!testContext.isStopped()) {
+                try {
+                    int key = random.nextInt(maxKeys);
+                    String res;
+                    switch ( requestSelector.select() ) {
+                        case PUT_REQUEST:
+                            int val = random.nextInt();
+                            res = putRequest("key/"+key+"/"+val);
+                            putKeyValues.put(key, res);
+
+                            log.info(id+": put key="+key+" val="+res);
+                            break;
+
+                        case GET_REQUEST:
+                            res = getRequest("key/"+key);
+
+                            assertEquals(id+": not what i put", res, putKeyValues.get(key) );
+
+                            log.info(id + ": get key=" + key + " val=" + res);
+                            break;
+                    }
+                }catch (IOException e){
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+
+        protected String getRequest(String restOpp) throws IOException {
+            HttpUriRequest request = new HttpGet(baseRul+restOpp);
+            return responseToString( client.execute(request) );
+        }
+
+        protected String putRequest(String restOpp)  throws IOException{
+            HttpUriRequest request = new HttpPut(baseRul+restOpp);
+            return responseToString( client.execute(request) );
+        }
+
+        protected String responseToString(HttpResponse response) throws IOException{
+            HttpEntity entity = response.getEntity();
+            return EntityUtils.toString(entity);
+        }
+    }
+
+    @Verify(global = true)
+    public void verify() throws Exception { }
+}

--- a/tests/src/main/resources/webapps/webapp/WEB-INF/lib/readme.txt
+++ b/tests/src/main/resources/webapps/webapp/WEB-INF/lib/readme.txt
@@ -1,0 +1,4 @@
+lib dir for web server.  place all jars needed by the tomcat server hear.
+
+As stabilizer is all ready loading Hazelcast jars,  and tomcat is starting in embeded mode,  tomcat will use the
+parent class loader to find the hazelcast jars.

--- a/tests/src/main/resources/webapps/webapp/WEB-INF/tomcat-hz.xml
+++ b/tests/src/main/resources/webapps/webapp/WEB-INF/tomcat-hz.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="ISO-8859-1" standalone="no"?>
+<!--
+  ~ Copyright (c) 2008-2013, Hazelcast, Inc. All Rights Reserved.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<web-app xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.5"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd">
+
+    <display-name>demo</display-name>
+    <filter>
+        <filter-name>hazelcast-filter</filter-name>
+        <filter-class>com.hazelcast.web.WebFilter</filter-class>
+        <init-param>
+            <param-name>map-name</param-name>
+            <param-value>default</param-value>
+        </init-param>
+        <init-param>
+            <param-name>sticky-session</param-name>
+            <param-value>false</param-value>
+        </init-param>
+        <init-param>
+            <param-name>debug</param-name>
+            <param-value>true</param-value>
+        </init-param>
+        <init-param>
+            <param-name>config-location</param-name>
+            <param-value>hazelcast.xml</param-value>
+        </init-param>
+        <init-param>
+            <param-name>instance-name</param-name>
+            <param-value>node-1</param-value>
+        </init-param>
+        <init-param>
+            <param-name>shutdown-on-destroy</param-name>
+            <param-value>true</param-value>
+        </init-param>
+        <init-param>
+            <param-name>use-client</param-name>
+            <param-value>false</param-value>
+        </init-param>
+        <init-param>
+            <param-name>deferred-write</param-name>
+            <param-value>false</param-value>
+        </init-param>
+    </filter>
+
+    <filter-mapping>
+        <filter-name>hazelcast-filter</filter-name>
+        <url-pattern>/*</url-pattern>
+        <dispatcher>FORWARD</dispatcher>
+        <dispatcher>INCLUDE</dispatcher>
+        <dispatcher>REQUEST</dispatcher>
+    </filter-mapping>
+
+    <servlet>
+      <servlet-name>test-servlet</servlet-name>
+      <servlet-class>com.hazelcast.stabilizer.tests.webContainer.KeyValueServlet</servlet-class>
+      <load-on-startup>1</load-on-startup>
+    </servlet>
+
+    <servlet-mapping>
+      <servlet-name>test-servlet</servlet-name>
+      <url-pattern>/*</url-pattern>
+    </servlet-mapping>
+
+    <listener>
+        <listener-class>com.hazelcast.web.SessionListener</listener-class>
+    </listener>
+</web-app>


### PR DESCRIPTION
... started under web container

a example run script   to start the tomcat servers

provisioner --scale ${boxCount}
provisioner --makeLB lb-tomcat
provisioner --agentsToLB lb-tomcat

coordinator 	--autoCreateHzInstances false \
		--memberWorkerCount ${members} \
	        --clientWorkerCount ${clients} \
	        --duration ${duration} \
	        --workerVmOptions "$memberJvmArgs" \
                --clientWorkerVmOptions "$clientJvmArgs" \
		--workerClassPath "/home/danny/hazelcast-stabilizer-0.4-SNAPSHOT/lib/tomcat*" \
	        --parallel \
	        test.properties


example stabilizer.props for the ELB
ELB_PROTOCOL=HTTP
ELB_PORT_IN=6555
ELB_PORT_OUT=6555
ELB_AZS=us-east-1a,us-east-1b,us-east-1d,us-east-1e

