### PR TITLE
Renewed resources upload feature

### DIFF
--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/agent/workerjvm/WorkerJvmLauncher.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/agent/workerjvm/WorkerJvmLauncher.java
@@ -37,11 +37,11 @@ public class WorkerJvmLauncher {
     private final static File STABILIZER_HOME = getStablizerHome();
     private final static String CLASSPATH_SEPARATOR = System.getProperty("path.separator");
     private final static AtomicLong WORKER_ID_GENERATOR = new AtomicLong();
-    private final static String WORKERS_PATH = "/home/users/stabilizer/hazelcast-stabilizer-0.4-SNAPSHOT/workers";
+    private final static String WORKERS_PATH = getStablizerHome().getAbsolutePath() + "/workers";
 
     private final WorkerJvmSettings settings;
     private final StabilizerProperties props = new StabilizerProperties();
-    private Bash bash = new Bash(props);
+    private final Bash bash = new Bash(props);
     private final Agent agent;
     private final ConcurrentMap<String, WorkerJvm> workerJVMs;
     private File hzFile;
@@ -138,7 +138,7 @@ public class WorkerJvmLauncher {
     private void copyResourcesToWorkerId(String workerId) throws IOException {
         final String testSuiteId = agent.getTestSuite().id;
         if (!new File(WORKERS_PATH + "/" + testSuiteId + "/upload/").exists()) {
-            log.debug("Skipping copy, since no copy file at the agent");
+            log.debug("Skip copying upload directory to workers since no upload directory was found");
             return;
         }
         String cpCommand = format("cp -rfv %s/%s/upload/* %s/%s/%s/",

--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/agent/workerjvm/WorkerJvmLauncher.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/agent/workerjvm/WorkerJvmLauncher.java
@@ -137,8 +137,8 @@ public class WorkerJvmLauncher {
 
     private void copyResourcesToWorkerId(String workerId) throws IOException {
         final String testSuiteId = agent.getTestSuite().id;
-        if (!new File(WORKERS_PATH + testSuiteId + "/upload/").exists()) {
-            log.info("Skipping copy, since no copy file at the agent");
+        if (!new File(WORKERS_PATH + "/" + testSuiteId + "/upload/").exists()) {
+            log.debug("Skipping copy, since no copy file at the agent");
             return;
         }
         String cpCommand = format("cp -rfv %s/%s/upload/* %s/%s/%s/",
@@ -148,7 +148,7 @@ public class WorkerJvmLauncher {
                 testSuiteId,
                 workerId);
         bash.execute(cpCommand);
-        log.info(format("Finished copying resources file '%s' to worker", WORKERS_PATH));
+        log.info(format("Finished copying '+%s+' to worker", WORKERS_PATH));
     }
 
     private void generateWorkerStartScript(String mode, WorkerJvm workerJvm) {

--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/agent/workerjvm/WorkerJvmLauncher.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/agent/workerjvm/WorkerJvmLauncher.java
@@ -8,7 +8,6 @@ import com.hazelcast.stabilizer.provisioner.Bash;
 import com.hazelcast.stabilizer.worker.ClientWorker;
 import com.hazelcast.stabilizer.worker.MemberWorker;
 import org.apache.log4j.Logger;
-import sun.security.ssl.Debug;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -137,7 +136,8 @@ public class WorkerJvmLauncher {
 
     private void copyResourcesToWorkerId(String workerId) throws IOException {
         final String testSuiteId = agent.getTestSuite().id;
-        if (!new File(WORKERS_PATH + "/" + testSuiteId + "/upload/").exists()) {
+        File uploadDirectory = new File(WORKERS_PATH + "/" + testSuiteId + "/upload/");
+        if (!uploadDirectory.exists()) {
             log.debug("Skip copying upload directory to workers since no upload directory was found");
             return;
         }

--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/agent/workerjvm/WorkerJvmLauncher.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/agent/workerjvm/WorkerJvmLauncher.java
@@ -137,6 +137,10 @@ public class WorkerJvmLauncher {
 
     private void copyResourcesToWorkerId(String workerId) throws IOException {
         final String testSuiteId = agent.getTestSuite().id;
+        if (!new File(WORKERS_PATH + testSuiteId + "/upload/").exists()) {
+            log.info("Skipping copy, since no copy file at the agent");
+            return;
+        }
         String cpCommand = format("cp -rfv %s/%s/upload/* %s/%s/%s/",
                 WORKERS_PATH,
                 testSuiteId,

--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/agent/workerjvm/WorkerJvmLauncher.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/agent/workerjvm/WorkerJvmLauncher.java
@@ -3,6 +3,8 @@ package com.hazelcast.stabilizer.agent.workerjvm;
 import com.hazelcast.stabilizer.Utils;
 import com.hazelcast.stabilizer.agent.Agent;
 import com.hazelcast.stabilizer.agent.SpawnWorkerFailedException;
+import com.hazelcast.stabilizer.common.StabilizerProperties;
+import com.hazelcast.stabilizer.provisioner.Bash;
 import com.hazelcast.stabilizer.worker.ClientWorker;
 import com.hazelcast.stabilizer.worker.MemberWorker;
 import org.apache.log4j.Logger;
@@ -34,8 +36,11 @@ public class WorkerJvmLauncher {
     private final static File STABILIZER_HOME = getStablizerHome();
     private final static String CLASSPATH_SEPARATOR = System.getProperty("path.separator");
     private final static AtomicLong WORKER_ID_GENERATOR = new AtomicLong();
+    private final String workersPath = "/home/users/stabilizer/hazelcast-stabilizer-0.4-SNAPSHOT/workers";
 
     private final WorkerJvmSettings settings;
+    private StabilizerProperties props = new StabilizerProperties();
+    private Bash bash = new Bash(props);
     private final Agent agent;
     private final ConcurrentMap<String, WorkerJvm> workerJVMs;
     private File hzFile;
@@ -124,8 +129,25 @@ public class WorkerJvmLauncher {
         new WorkerJvmProcessOutputGobbler(process.getInputStream(), new FileOutputStream(logFile)).start();
         workerJvm.process = process;
         workerJvm.mode = WorkerJvm.Mode.valueOf(mode.toUpperCase());
+        uploadResourcesToWorker(workerId);
         workerJVMs.put(workerId, workerJvm);
         return workerJvm;
+    }
+
+    private void uploadResourcesToWorker(String workerId) throws IOException {
+        final String testSuiteId = agent.getTestSuite().id;
+        if(!new File(workersPath + testSuiteId + "/resources/").exists()){
+            log.info("Resources files are not in the agent");
+            return;
+        }
+        String cpCommand = format("cp -rfv %s/%s/resources/* %s/%s/%s/",
+                workersPath,
+                testSuiteId,
+                workersPath,
+                testSuiteId,
+                workerId);
+        bash.execute(cpCommand);
+        log.info(format("Finished copying resource files from agent to worker"));
     }
 
     private void generateWorkerStartScript(String mode, WorkerJvm workerJvm) {

--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/agent/workerjvm/WorkerJvmLauncher.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/agent/workerjvm/WorkerJvmLauncher.java
@@ -136,7 +136,7 @@ public class WorkerJvmLauncher {
 
     private void uploadResourcesToWorker(String workerId) throws IOException {
         final String testSuiteId = agent.getTestSuite().id;
-        if(!new File(workersPath + testSuiteId + "/resources/").exists()){
+        if(!new File(workersPath + "/" + testSuiteId + "/resources/").exists()){
             log.info("Resources files are not in the agent");
             return;
         }

--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/coordinator/Coordinator.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/coordinator/Coordinator.java
@@ -52,7 +52,9 @@ import static java.lang.String.format;
 public class Coordinator {
 
     public final static File STABILIZER_HOME = getStablizerHome();
-    public final static String UPLOAD_HOME = STABILIZER_HOME.getAbsolutePath() + "/upload";
+    public final static String WORKING_DIRECTORY = new String(System.getProperty("user.dir"));
+    public final static File UPLOAD_DIRECTORY = new File(WORKING_DIRECTORY, "upload");
+    public final static String UPLOAD_HOME = UPLOAD_DIRECTORY.getAbsolutePath();
     private final static Logger log = Logger.getLogger(Coordinator.class);
 
     //options.
@@ -124,7 +126,7 @@ public class Coordinator {
 
         agentsClient.initTestSuite(testSuite);
 
-        uploadResourcesToAgents();
+        copyUploadDirectoryToAgents();
         uploadWorkerClassPath();
         //todo: copy the hazelcast jars
         uploadYourKitIfNeeded();
@@ -374,12 +376,13 @@ public class Coordinator {
         log.info(msg);
     }
 
-    private void uploadResourcesToAgents() throws IOException {
-        if (!new File(UPLOAD_HOME).exists()) {
-            log.info("Skipping upload, since no upload file in working directory");
+    private void copyUploadDirectoryToAgents() throws IOException {
+        log.info("WORKING DIRECTORY:" + WORKING_DIRECTORY);
+        if (!UPLOAD_DIRECTORY.exists()) {
+            log.debug("Skipping upload, since no upload file in working directory");
             return;
         }
-        log.info("UPLOAD HOME:" + UPLOAD_HOME);
+        log.info("UPLOAD DIRECTORY:" + UPLOAD_HOME);
         List<File> files = Utils.getFilesFromClassPath(UPLOAD_HOME);
         for (String ip : agentsClient.getPublicAddresses()){
             for (File file : files){
@@ -394,7 +397,7 @@ public class Coordinator {
             }
             log.info("    " + ip + " copied");
         }
-        log.info(format("Finished copying resources file '%s' to agents", UPLOAD_HOME));
+        log.info(format("Finished copying '+%s+' to agents", UPLOAD_HOME));
     }
 
 

--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/coordinator/Coordinator.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/coordinator/Coordinator.java
@@ -52,9 +52,8 @@ import static java.lang.String.format;
 public class Coordinator {
 
     public final static File STABILIZER_HOME = getStablizerHome();
-    public final static String WORKING_DIRECTORY = new String(System.getProperty("user.dir"));
+    public final static File WORKING_DIRECTORY = new File(System.getProperty("user.dir"));
     public final static File UPLOAD_DIRECTORY = new File(WORKING_DIRECTORY, "upload");
-    public final static String UPLOAD_HOME = UPLOAD_DIRECTORY.getAbsolutePath();
     private final static Logger log = Logger.getLogger(Coordinator.class);
 
     //options.
@@ -377,14 +376,15 @@ public class Coordinator {
     }
 
     private void copyUploadDirectoryToAgents() throws IOException {
-        log.info("WORKING DIRECTORY:" + WORKING_DIRECTORY);
+        log.info("WORKING DIRECTORY:" + WORKING_DIRECTORY.getAbsolutePath());
         if (!UPLOAD_DIRECTORY.exists()) {
             log.debug("Skipping upload, since no upload file in working directory");
             return;
         }
-        log.info("UPLOAD DIRECTORY:" + UPLOAD_HOME);
-        List<File> files = Utils.getFilesFromClassPath(UPLOAD_HOME);
+        log.info(format("Starting uploading '+%s+' to agents", UPLOAD_DIRECTORY.getAbsolutePath()));
+        List<File> files = Utils.getFilesFromClassPath(UPLOAD_DIRECTORY.getAbsolutePath());
         for (String ip : agentsClient.getPublicAddresses()){
+            log.info(format(" Uploading '+%s+' to agent %s", UPLOAD_DIRECTORY.getAbsolutePath(), ip));
             for (File file : files){
                 String syncCommand = format("rsync -avv -e \"ssh %s\" %s %s@%s:hazelcast-stabilizer-%s/workers/%s/",
                         props.get("SSH_OPTIONS", ""),
@@ -397,7 +397,7 @@ public class Coordinator {
             }
             log.info("    " + ip + " copied");
         }
-        log.info(format("Finished copying '+%s+' to agents", UPLOAD_HOME));
+        log.info(format("Finished uploading '+%s+' to agents", UPLOAD_DIRECTORY.getAbsolutePath()));
     }
 
 

--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/coordinator/Coordinator.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/coordinator/Coordinator.java
@@ -376,7 +376,6 @@ public class Coordinator {
     }
 
     private void copyUploadDirectoryToAgents() throws IOException {
-        log.info("WORKING DIRECTORY:" + WORKING_DIRECTORY.getAbsolutePath());
         if (!UPLOAD_DIRECTORY.exists()) {
             log.debug("Skipping upload, since no upload file in working directory");
             return;

--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/coordinator/Coordinator.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/coordinator/Coordinator.java
@@ -52,7 +52,7 @@ import static java.lang.String.format;
 public class Coordinator {
 
     public final static File STABILIZER_HOME = getStablizerHome();
-    public final static String RESOURCES_HOME = STABILIZER_HOME.getAbsolutePath() + "/resources";
+    public final static String UPLOAD_HOME = STABILIZER_HOME.getAbsolutePath() + "/upload";
     private final static Logger log = Logger.getLogger(Coordinator.class);
 
     //options.
@@ -375,12 +375,8 @@ public class Coordinator {
     }
 
     private void uploadResourcesToAgents() throws IOException {
-        if(!new File(RESOURCES_HOME).exists()){
-            log.info("Resource files does not exist");
-            return;
-        }
-        log.info("RESOURCES HOME:" + RESOURCES_HOME);
-        List<File> files = Utils.getFilesFromClassPath(RESOURCES_HOME);
+        log.info("UPLOAD HOME:" + UPLOAD_HOME);
+        List<File> files = Utils.getFilesFromClassPath(UPLOAD_HOME);
         for (String ip : agentsClient.getPublicAddresses()){
             for (File file : files){
                 String syncCommand = format("rsync -avv -e \"ssh %s\" %s %s@%s:hazelcast-stabilizer-%s/workers/%s/",
@@ -394,7 +390,7 @@ public class Coordinator {
             }
             log.info("    " + ip + " copied");
         }
-        log.info(format("Finished copying resources file '%s' to agents", RESOURCES_HOME));
+        log.info(format("Finished copying resources file '%s' to agents", UPLOAD_HOME));
     }
 
 

--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/coordinator/Coordinator.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/coordinator/Coordinator.java
@@ -124,7 +124,7 @@ public class Coordinator {
 
         agentsClient.initTestSuite(testSuite);
 
-        uploadResourcesToWorkers();
+        uploadResourcesToAgents();
         uploadWorkerClassPath();
         //todo: copy the hazelcast jars
         uploadYourKitIfNeeded();
@@ -374,11 +374,12 @@ public class Coordinator {
         log.info(msg);
     }
 
-    private void uploadResourcesToWorkers() throws IOException {
-        if(RESOURCES_HOME == null){
+    private void uploadResourcesToAgents() throws IOException {
+        if(!new File(RESOURCES_HOME).exists()){
             log.info("Resource files does not exist");
+            return;
         }
-        log.info("RESOURCES_HOME:" + RESOURCES_HOME);
+        log.info("RESOURCES HOME:" + RESOURCES_HOME);
         List<File> files = Utils.getFilesFromClassPath(RESOURCES_HOME);
         for (String ip : agentsClient.getPublicAddresses()){
             for (File file : files){

--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/coordinator/Coordinator.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/coordinator/Coordinator.java
@@ -375,6 +375,10 @@ public class Coordinator {
     }
 
     private void uploadResourcesToAgents() throws IOException {
+        if (!new File(UPLOAD_HOME).exists()) {
+            log.info("Skipping upload, since no upload file in working directory");
+            return;
+        }
         log.info("UPLOAD HOME:" + UPLOAD_HOME);
         List<File> files = Utils.getFilesFromClassPath(UPLOAD_HOME);
         for (String ip : agentsClient.getPublicAddresses()){


### PR DESCRIPTION
- added uploadResourcesToWorkers() to Coordinator but it has not spec file on CoordinatorCli.
-  Firstly user must upload resources file to **/hazelcast-stabilizer/dist/src/main/dist/resources**  at his/her local working directory.