### PR TITLE
Added SlowOperationMapTest

### DIFF
--- a/dist/src/main/dist/tests/slow/slow-operation-map.properties
+++ b/dist/src/main/dist/tests/slow/slow-operation-map.properties
@@ -1,0 +1,4 @@
+class=com.hazelcast.stabilizer.tests.slow.SlowOperationMapTest
+threadCount=10
+putProb=0.5
+recursionDepth=10

--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/utils/ReflectionUtils.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/utils/ReflectionUtils.java
@@ -87,6 +87,22 @@ public class ReflectionUtils {
     }
 
     /**
+     * Searches a method by name.
+     *
+     * @param classType     Class to scan
+     * @param methodName    Name of the method
+     * @return the found method or <tt>null</tt> if no method was found
+     */
+    public static Method getMethodByName(Class classType, String methodName) {
+        for (Method method : classType.getDeclaredMethods()) {
+            if (method.getName().equals(methodName)) {
+                return method;
+            }
+        }
+        return null;
+    }
+
+    /**
      * Searches for an optional void method of the given annotation type and skips the arguments check.
      *
      * @param classType      Class to scan

--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/slow/SlowOperationMapTest.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/slow/SlowOperationMapTest.java
@@ -1,0 +1,212 @@
+package com.hazelcast.stabilizer.tests.slow;
+
+import com.hazelcast.core.IMap;
+import com.hazelcast.instance.Node;
+import com.hazelcast.logging.ILogger;
+import com.hazelcast.logging.Logger;
+import com.hazelcast.map.MapInterceptor;
+import com.hazelcast.spi.impl.InternalOperationService;
+import com.hazelcast.stabilizer.Utils;
+import com.hazelcast.stabilizer.test.TestContext;
+import com.hazelcast.stabilizer.test.TestRunner;
+import com.hazelcast.stabilizer.test.annotations.RunWithWorker;
+import com.hazelcast.stabilizer.test.annotations.Setup;
+import com.hazelcast.stabilizer.test.annotations.Teardown;
+import com.hazelcast.stabilizer.test.annotations.Verify;
+import com.hazelcast.stabilizer.test.annotations.Warmup;
+import com.hazelcast.stabilizer.test.utils.ExceptionReporter;
+import com.hazelcast.stabilizer.tests.helpers.KeyLocality;
+import com.hazelcast.stabilizer.tests.helpers.KeyUtils;
+import com.hazelcast.stabilizer.worker.OperationSelector;
+import com.hazelcast.stabilizer.worker.tasks.AbstractWorkerTask;
+
+import java.lang.reflect.Method;
+import java.util.Collection;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static com.hazelcast.stabilizer.tests.helpers.HazelcastTestUtils.getNode;
+import static com.hazelcast.stabilizer.tests.helpers.HazelcastTestUtils.getOperationCountInformation;
+import static com.hazelcast.stabilizer.tests.helpers.HazelcastTestUtils.waitClusterSize;
+import static com.hazelcast.stabilizer.utils.ReflectionUtils.getMethodByName;
+import static com.hazelcast.stabilizer.utils.ReflectionUtils.invokeMethod;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * This test invokes slowed down map operations on a Hazelcast instance to provoke slow operation logs.
+ */
+public class SlowOperationMapTest {
+    private static final ILogger log = Logger.getLogger(SlowOperationMapTest.class);
+
+    private static enum Operation {
+        PUT,
+        GET
+    }
+
+    // properties
+    public int keyLength = 10;
+    public int valueLength = 10;
+    public int keyCount = 100;
+    public int valueCount = 100;
+    public String basename = "slowOperationTestMap";
+    public KeyLocality keyLocality = KeyLocality.Random;
+    public int minNumberOfMembers = 0;
+    public double putProb = 0.5;
+    public int recursionDepth = 10;
+
+    private final AtomicLong putCounter = new AtomicLong(0);
+    private final AtomicLong getCounter = new AtomicLong(0);
+
+    private TestContext testContext;
+    private IMap<Integer, Integer> map;
+    private Method getSlowOperationLogsMethod;
+    private int[] keys;
+
+    @Setup
+    public void setup(TestContext testContext) throws Exception {
+        this.testContext = testContext;
+        map = testContext.getTargetInstance().getMap(basename + "-" + testContext.getTestId());
+
+        // try to find the getSlowOperationLogs method (since Hazelcast 3.5)
+        getSlowOperationLogsMethod = getMethodByName(InternalOperationService.class, "getSlowOperationLogs");
+        if (getSlowOperationLogsMethod == null) {
+            fail("This test needs Hazelcast 3.5 or newer");
+        }
+    }
+
+    @Teardown
+    public void teardown() throws Exception {
+        map.destroy();
+        log.info(getOperationCountInformation(testContext.getTargetInstance()));
+    }
+
+    @Warmup(global = false)
+    public void warmup() throws InterruptedException {
+        waitClusterSize(log, testContext.getTargetInstance(), minNumberOfMembers);
+        keys = KeyUtils.generateIntKeys(keyCount, Integer.MAX_VALUE, keyLocality, testContext.getTargetInstance());
+
+        Random random = new Random();
+        for (int key : keys) {
+            int value = random.nextInt(Integer.MAX_VALUE);
+            map.put(key, value);
+        }
+
+        // add the interceptor after the warmup, otherwise this stage will take ages
+        map.addInterceptor(new SlowMapInterceptor(recursionDepth));
+    }
+
+    @Verify(global = true)
+    public void verify() throws Exception {
+        long operationCount = putCounter.get() + getCounter.get();
+        assertTrue("Expected at least one completed operations, but was " + operationCount, operationCount > 0);
+
+        Collection<Object> logs = null;
+        try {
+            Node node = getNode(testContext.getTargetInstance());
+            InternalOperationService operationService = ((InternalOperationService) node.nodeEngine.getOperationService());
+            logs = invokeMethod(operationService, getSlowOperationLogsMethod);
+        } catch (Throwable t) {
+            ExceptionReporter.report(testContext.getTestId(), t);
+        }
+        if (logs == null) {
+            fail("Could not retrieve slow operation logs");
+        }
+
+        long actual = logs.size();
+        long expected = Math.max(putCounter.get(), 1) + Math.max(getCounter.get(), 1);
+        assertTrue("Expected " + expected + " slow operation logs, but was " + actual, actual == expected);
+
+        log.info("Found " + actual + " slow query logs after completing " + operationCount + " operations.");
+    }
+
+    @RunWithWorker
+    public AbstractWorkerTask<Operation> createBaseWorker() {
+        return new WorkerTask();
+    }
+
+    private class WorkerTask extends AbstractWorkerTask<Operation> {
+
+        @Override
+        protected OperationSelector<Operation> createOperationSelector() {
+            return new OperationSelector<Operation>().addOperation(Operation.PUT, putProb)
+                                                     .addOperationRemainingProbability(Operation.GET);
+        }
+
+        @Override
+        protected void doRun(Operation operation) {
+            int key = randomKey();
+
+            switch (operation) {
+                case PUT:
+                    map.put(key, randomValue());
+                    putCounter.incrementAndGet();
+                    break;
+                case GET:
+                    map.get(key);
+                    getCounter.incrementAndGet();
+                    break;
+                default:
+                    throw new UnsupportedOperationException();
+            }
+        }
+
+        private int randomKey() {
+            return keys[nextInt(keys.length)];
+        }
+
+        private int randomValue() {
+            return nextInt(Integer.MAX_VALUE);
+        }
+    }
+
+    private static class SlowMapInterceptor implements MapInterceptor {
+        private final int recursionDepth;
+
+        public SlowMapInterceptor(int recursionDepth) {
+            this.recursionDepth = recursionDepth;
+        }
+
+        @Override
+        public Object interceptGet(Object value) {
+            return null;
+        }
+
+        @Override
+        public void afterGet(Object value) {
+            sleepRecursion(recursionDepth, 15);
+        }
+
+        @Override
+        public Object interceptPut(Object oldValue, Object newValue) {
+            return null;
+        }
+
+        @Override
+        public void afterPut(Object value) {
+            sleepRecursion(recursionDepth, 20);
+        }
+
+        @Override
+        public Object interceptRemove(Object removedValue) {
+            return null;
+        }
+
+        @Override
+        public void afterRemove(Object removedValue) {
+        }
+
+        private void sleepRecursion(int recursionDepth, int sleepSeconds) {
+            if (recursionDepth == 0) {
+                Utils.sleepSeconds(sleepSeconds);
+                return;
+            }
+            sleepRecursion(recursionDepth - 1, sleepSeconds);
+        }
+    }
+
+    public static void main(String[] args) throws Throwable {
+        SlowOperationMapTest test = new SlowOperationMapTest();
+        new TestRunner<SlowOperationMapTest>(test).run();
+    }
+}


### PR DESCRIPTION
Added SlowOperationMapTest to trigger slow operation logs in Hazelcast 3.5 or newer. This test is a fulfillment for the `Hogging Partition Thread` feature for Hazelcast 3.5.

Here is a sample worker.log from a successful run:
https://gist.github.com/Donnerbart/20cc7c6b77e252c567f5

If you run the test with an older version (or rather a version without the `SlowOperationDetector`) the test will through an assert: `java.lang.AssertionError: This test needs Hazelcast 3.5 or newer`