### PR TITLE
Fixed NPE during tests with OperationSelectorBuilder

### DIFF
--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/worker/selector/OperationSelectorBuilder.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/worker/selector/OperationSelectorBuilder.java
@@ -102,8 +102,9 @@ public class OperationSelectorBuilder<T extends Enum<T>> {
         for (Map.Entry<T, Double> entry : operations.entrySet()) {
             T operation = entry.getKey();
             for (int i = 0; i < Math.round(entry.getValue() * arraySize); i++) {
-                if (++index < arraySize) {
+                if (index < arraySize) {
                     operationsArray[index] = operation;
+                    index++;
                 }
             }
         }


### PR DESCRIPTION
Fixed off-by-one error in `OperationSelectorBuilder` during population of array (index started at 1 instead of 0).

Fixed cleanup of `MapTransactionReadWriteTest` (one selector per thread, removed warnings).