### PR TITLE
Cleanup of MapAsyncOpsTest && beforeRun() and afterRun() for AbstractWorkerTask

### DIFF
--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/worker/tasks/AsyncAbstractWorkerTask.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/worker/tasks/AsyncAbstractWorkerTask.java
@@ -22,7 +22,7 @@ public abstract class AsyncAbstractWorkerTask<O extends Enum<O>, V> extends Abst
     @Override
     public void run() {
         while (!testContext.isStopped()) {
-            doRun(selector.select());
+            doIteration(selector.select());
         }
         operationCount.addAndGet(iteration % performanceUpdateFrequency);
     }
@@ -41,7 +41,16 @@ public abstract class AsyncAbstractWorkerTask<O extends Enum<O>, V> extends Abst
         handleFailure(t);
     }
 
+    /**
+     * Will be called on {@link ExecutionCallback#onResponse(Object)} after the iteration has been increased.
+     *
+     * @param response the result of the successful execution
+     */
     protected abstract void handleResponse(V response);
 
+    /**
+     * Will be called on {@link ExecutionCallback#onFailure(Throwable)} after the throwable has been reported.
+     * @param t the exception that is thrown
+     */
     protected abstract void handleFailure(Throwable t);
 }

--- a/stabilizer/src/test/java/com/hazelcast/stabilizer/worker/TestContainerTest.java
+++ b/stabilizer/src/test/java/com/hazelcast/stabilizer/worker/TestContainerTest.java
@@ -66,7 +66,7 @@ public class TestContainerTest {
         }
 
         @RunWithWorker
-        public AbstractWorkerTask createBaseWorker() {
+        public AbstractWorkerTask createWorker() {
             return null;
         }
     }
@@ -175,10 +175,10 @@ public class TestContainerTest {
         boolean runWithWorkerCalled;
 
         @RunWithWorker
-        AbstractWorkerTask<Operation> createBaseWorker() {
+        AbstractWorkerTask<Operation> createWorker() {
             return new AbstractWorkerTask<Operation>(builder) {
                 @Override
-                protected void doRun(Operation operation) {
+                protected void doIteration(Operation operation) {
                     runWithWorkerCalled = true;
                 }
             };

--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/map/IntIntMapTest.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/map/IntIntMapTest.java
@@ -96,7 +96,7 @@ public class IntIntMapTest {
     }
 
     @RunWithWorker
-    public AbstractWorkerTask<Operation> createBaseWorker() {
+    public AbstractWorkerTask<Operation> createWorker() {
         return new WorkerTask();
     }
 
@@ -107,7 +107,7 @@ public class IntIntMapTest {
         }
 
         @Override
-        protected void doRun(Operation operation) {
+        protected void doIteration(Operation operation) {
             int key = randomKey();
 
             switch (operation) {
@@ -134,11 +134,11 @@ public class IntIntMapTest {
         }
 
         private int randomKey() {
-            return keys[nextInt(keys.length)];
+            return keys[randomInt(keys.length)];
         }
 
         private int randomValue() {
-            return nextInt(Integer.MAX_VALUE);
+            return randomInt(Integer.MAX_VALUE);
         }
     }
 

--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/map/StringStringMapTest.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/map/StringStringMapTest.java
@@ -99,7 +99,7 @@ public class StringStringMapTest {
     }
 
     @RunWithWorker
-    public AbstractWorkerTask<Operation> createBaseWorker() {
+    public AbstractWorkerTask<Operation> createWorker() {
         return new WorkerTask();
     }
 
@@ -110,7 +110,7 @@ public class StringStringMapTest {
         }
 
         @Override
-        protected void doRun(Operation operation) {
+        protected void doIteration(Operation operation) {
             String key = randomKey();
 
             switch (operation) {
@@ -137,11 +137,11 @@ public class StringStringMapTest {
         }
 
         private String randomKey() {
-            return keys[nextInt(keys.length)];
+            return keys[randomInt(keys.length)];
         }
 
         private String randomValue() {
-            return values[nextInt(values.length)];
+            return values[randomInt(values.length)];
         }
     }
 

--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/slow/SlowOperationMapTest.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/slow/SlowOperationMapTest.java
@@ -125,7 +125,7 @@ public class SlowOperationMapTest {
     }
 
     @RunWithWorker
-    public AbstractWorkerTask<Operation> createBaseWorker() {
+    public AbstractWorkerTask<Operation> createWorker() {
         return new WorkerTask();
     }
 
@@ -136,7 +136,7 @@ public class SlowOperationMapTest {
         }
 
         @Override
-        protected void doRun(Operation operation) {
+        protected void doIteration(Operation operation) {
             int key = randomKey();
 
             switch (operation) {
@@ -154,11 +154,11 @@ public class SlowOperationMapTest {
         }
 
         private int randomKey() {
-            return keys[nextInt(keys.length)];
+            return keys[randomInt(keys.length)];
         }
 
         private int randomValue() {
-            return nextInt(Integer.MAX_VALUE);
+            return randomInt(Integer.MAX_VALUE);
         }
     }
 

--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/syntheticmap/StringStringSyntheticMapTest.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/syntheticmap/StringStringSyntheticMapTest.java
@@ -83,7 +83,7 @@ public class StringStringSyntheticMapTest {
     }
 
     @RunWithWorker
-    public AbstractWorkerTask<Operation> createBaseWorker() {
+    public AbstractWorkerTask<Operation> createWorker() {
         return new WorkerTask();
     }
 
@@ -94,7 +94,7 @@ public class StringStringSyntheticMapTest {
         }
 
         @Override
-        protected void doRun(Operation operation) {
+        protected void doIteration(Operation operation) {
             String key = randomKey();
 
             switch (operation) {
@@ -117,11 +117,11 @@ public class StringStringSyntheticMapTest {
         }
 
         private String randomKey() {
-            return keys[nextInt(keys.length)];
+            return keys[randomInt(keys.length)];
         }
 
         private String randomValue() {
-            return values[nextInt(values.length)];
+            return values[randomInt(values.length)];
         }
     }
 


### PR DESCRIPTION
* Cleanup of `MapAsyncOpsTest`
* Introducing optional `beforeRun()` and `afterRun()` method for `AbstractWorkerTask`
* Renamed some methods and added documentation.