### PR TITLE
Cleanup of MapCasTest && AbstractMonotonicWorkerTask

### DIFF
--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/worker/tasks/AbstractAsyncWorkerTask.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/worker/tasks/AbstractAsyncWorkerTask.java
@@ -12,30 +12,30 @@ import com.hazelcast.stabilizer.worker.selector.OperationSelectorBuilder;
  * @param <O> Type of Enum used by the {@link com.hazelcast.stabilizer.worker.selector.OperationSelector}
  * @param <V> Type of {@link com.hazelcast.core.ExecutionCallback}
  */
-public abstract class AsyncAbstractWorkerTask<O extends Enum<O>, V> extends AbstractWorkerTask<O>
+public abstract class AbstractAsyncWorkerTask<O extends Enum<O>, V> extends AbstractWorkerTask<O>
         implements ExecutionCallback<V> {
 
-    public AsyncAbstractWorkerTask(OperationSelectorBuilder<O> operationSelectorBuilder) {
+    public AbstractAsyncWorkerTask(OperationSelectorBuilder<O> operationSelectorBuilder) {
         super(operationSelectorBuilder);
     }
 
     @Override
-    public void run() {
+    public final void run() {
         while (!testContext.isStopped()) {
-            doIteration(selector.select());
+            timeStep(selector.select());
         }
         operationCount.addAndGet(iteration % performanceUpdateFrequency);
     }
 
     @Override
-    public void onResponse(V response) {
+    public final void onResponse(V response) {
         increaseIteration();
 
         handleResponse(response);
     }
 
     @Override
-    public void onFailure(Throwable t) {
+    public final void onFailure(Throwable t) {
         ExceptionReporter.report(testContext.getTestId(), t);
 
         handleFailure(t);

--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/worker/tasks/AbstractMonotonicWorkerTask.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/worker/tasks/AbstractMonotonicWorkerTask.java
@@ -1,0 +1,41 @@
+package com.hazelcast.stabilizer.worker.tasks;
+
+/**
+ * Monotonic version of {@link AbstractWorkerTask}.
+ * <p/>
+ * This worker provides no {@link com.hazelcast.stabilizer.worker.selector.OperationSelector}, just a simple {@link #timeStep()}
+ * method without parameters.
+ */
+public abstract class AbstractMonotonicWorkerTask extends AbstractWorkerTask {
+
+    @Override
+    public final void run() {
+        beforeRun();
+
+        while (!testContext.isStopped()) {
+            timeStep();
+
+            increaseIteration();
+        }
+        operationCount.addAndGet(iteration % performanceUpdateFrequency);
+
+        afterRun();
+    }
+
+    /**
+     * Fake implementation of abstract method, should not be used.
+     *
+     * @param operation ignored
+     */
+    @Override
+    protected final void timeStep(Enum operation) {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * This method is called for each iteration of {@link #run()}.
+     * <p/>
+     * Won't be called if an error occurs in {@link #beforeRun()}.
+     */
+    protected abstract void timeStep();
+}

--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/worker/tasks/AbstractWorkerTask.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/worker/tasks/AbstractWorkerTask.java
@@ -15,7 +15,7 @@ import java.util.concurrent.atomic.AtomicLong;
  * methods.
  * <p/>
  * Implicitly logs and measures performance. The related properties can be overwritten with the properties of the test.
- * The Operation counter is automatically increased after each {@link #doIteration(Enum)} call.
+ * The Operation counter is automatically increased after each {@link #timeStep(Enum)} call.
  *
  * @param <O> Type of Enum used by the {@link com.hazelcast.stabilizer.worker.selector.OperationSelector}
  */
@@ -41,12 +41,19 @@ public abstract class AbstractWorkerTask<O extends Enum<O>> implements Runnable 
         this.selector = operationSelectorBuilder.build();
     }
 
+    /**
+     * This constructor is just for child classes who also override the {@link #run()} method.
+     */
+    AbstractWorkerTask() {
+        this.selector = null;
+    }
+
     @Override
     public void run() {
         beforeRun();
 
         while (!testContext.isStopped()) {
-            doIteration(selector.select());
+            timeStep(selector.select());
 
             increaseIteration();
         }
@@ -80,12 +87,12 @@ public abstract class AbstractWorkerTask<O extends Enum<O>> implements Runnable 
      *
      * @param operation The selected operation for this iteration
      */
-    protected abstract void doIteration(O operation);
+    protected abstract void timeStep(O operation);
 
     /**
      * Override this method if you need to execute code after {@link #run()} is called.
      * <p/>
-     * Won't be called if an error occurs in {@link #beforeRun()} or {@link #doIteration(Enum)}.
+     * Won't be called if an error occurs in {@link #beforeRun()} or {@link #timeStep(Enum)}.
      */
     protected void afterRun() {
     }

--- a/stabilizer/src/test/java/com/hazelcast/stabilizer/worker/TestContainerTest.java
+++ b/stabilizer/src/test/java/com/hazelcast/stabilizer/worker/TestContainerTest.java
@@ -178,7 +178,7 @@ public class TestContainerTest {
         AbstractWorkerTask<Operation> createWorker() {
             return new AbstractWorkerTask<Operation>(builder) {
                 @Override
-                protected void doIteration(Operation operation) {
+                protected void timeStep(Operation operation) {
                     runWithWorkerCalled = true;
                 }
             };

--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/map/IntIntMapTest.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/map/IntIntMapTest.java
@@ -107,7 +107,7 @@ public class IntIntMapTest {
         }
 
         @Override
-        protected void doIteration(Operation operation) {
+        protected void timeStep(Operation operation) {
             int key = randomKey();
 
             switch (operation) {

--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/map/MapAsyncOpsTest.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/map/MapAsyncOpsTest.java
@@ -86,7 +86,7 @@ public class MapAsyncOpsTest {
         }
 
         @Override
-        protected void doIteration(Operation operation) {
+        protected void timeStep(Operation operation) {
             int key = randomInt(keyCount);
             switch (operation) {
                 case PUT_ASYNC:

--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/map/StringStringMapTest.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/map/StringStringMapTest.java
@@ -110,7 +110,7 @@ public class StringStringMapTest {
         }
 
         @Override
-        protected void doIteration(Operation operation) {
+        protected void timeStep(Operation operation) {
             String key = randomKey();
 
             switch (operation) {

--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/slow/SlowOperationMapTest.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/slow/SlowOperationMapTest.java
@@ -136,7 +136,7 @@ public class SlowOperationMapTest {
         }
 
         @Override
-        protected void doIteration(Operation operation) {
+        protected void timeStep(Operation operation) {
             int key = randomKey();
 
             switch (operation) {

--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/syntheticmap/StringStringSyntheticMapTest.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/syntheticmap/StringStringSyntheticMapTest.java
@@ -94,7 +94,7 @@ public class StringStringSyntheticMapTest {
         }
 
         @Override
-        protected void doIteration(Operation operation) {
+        protected void timeStep(Operation operation) {
             String key = randomKey();
 
             switch (operation) {


### PR DESCRIPTION
* Cleanup of `MapCasTest`
* Introducing `AbstractMonotonicWorkerTask` for worker tasks which will not use an `OperationSelector`

This PR depends on #517 (it won't even compile without those changes).