### PR TITLE
Cleanup of MapEntryListenerTest

### DIFF
--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/worker/TestContainer.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/worker/TestContainer.java
@@ -363,6 +363,9 @@ public class TestContainer<T extends TestContext> {
             spawner.spawn(abstractWorkerTask);
         }
         spawner.awaitCompletion();
+
+        // call the afterCompletion method on a single instance of the worker
+        operationCountWorkerTaskInstance.afterCompletion();
     }
 
     private Field getFieldFromBaseWorkerTask(String fieldName, Class fieldType) {

--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/worker/tasks/AbstractWorkerTask.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/worker/tasks/AbstractWorkerTask.java
@@ -4,6 +4,7 @@ import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
 import com.hazelcast.stabilizer.test.TestContext;
 import com.hazelcast.stabilizer.test.annotations.Performance;
+import com.hazelcast.stabilizer.test.utils.ThreadSpawner;
 import com.hazelcast.stabilizer.worker.selector.OperationSelector;
 import com.hazelcast.stabilizer.worker.selector.OperationSelectorBuilder;
 
@@ -75,7 +76,7 @@ public abstract class AbstractWorkerTask<O extends Enum<O>> implements Runnable 
     }
 
     /**
-     * Override this method if you need to execute code before {@link #run()} is called.
+     * Override this method if you need to execute code on each worker before {@link #run()} is called.
      */
     protected void beforeRun() {
     }
@@ -90,11 +91,19 @@ public abstract class AbstractWorkerTask<O extends Enum<O>> implements Runnable 
     protected abstract void timeStep(O operation);
 
     /**
-     * Override this method if you need to execute code after {@link #run()} is called.
+     * Override this method if you need to execute code on each worker after {@link #run()} is called.
      * <p/>
      * Won't be called if an error occurs in {@link #beforeRun()} or {@link #timeStep(Enum)}.
      */
     protected void afterRun() {
+    }
+
+    /**
+     * Override this method if you need to execute code once after all workers have finished their run phase.
+     * <p/>
+     * Will be executed after {@link ThreadSpawner#awaitCompletion()} on a single worker instance.
+     */
+    public void afterCompletion() {
     }
 
     /**

--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/map/MapEntryListenerTest.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/map/MapEntryListenerTest.java
@@ -20,37 +20,51 @@ import com.hazelcast.core.IList;
 import com.hazelcast.core.IMap;
 import com.hazelcast.logging.ILogger;
 import com.hazelcast.logging.Logger;
-import com.hazelcast.stabilizer.tests.helpers.StringUtils;
-import com.hazelcast.stabilizer.tests.map.helpers.EntryListenerImpl;
-import com.hazelcast.stabilizer.tests.map.helpers.EventCount;
-import com.hazelcast.stabilizer.tests.map.helpers.ScrambledZipfianGenerator;
 import com.hazelcast.stabilizer.test.TestContext;
-import com.hazelcast.stabilizer.test.annotations.Run;
+import com.hazelcast.stabilizer.test.annotations.RunWithWorker;
 import com.hazelcast.stabilizer.test.annotations.Setup;
 import com.hazelcast.stabilizer.test.annotations.Teardown;
 import com.hazelcast.stabilizer.test.annotations.Verify;
 import com.hazelcast.stabilizer.test.annotations.Warmup;
-import com.hazelcast.stabilizer.test.utils.ThreadSpawner;
-
-import java.util.Random;
+import com.hazelcast.stabilizer.tests.helpers.StringUtils;
+import com.hazelcast.stabilizer.tests.map.helpers.EventCount;
+import com.hazelcast.stabilizer.tests.map.helpers.EntryListenerImpl;
+import com.hazelcast.stabilizer.tests.map.helpers.ScrambledZipfianGenerator;
+import com.hazelcast.stabilizer.worker.selector.OperationSelector;
+import com.hazelcast.stabilizer.worker.selector.OperationSelectorBuilder;
+import com.hazelcast.stabilizer.worker.tasks.AbstractWorkerTask;
 
 import static com.hazelcast.stabilizer.utils.CommonUtils.sleepMillis;
 import static org.junit.Assert.assertEquals;
 
 /**
- * This test is using a map to generate map entry Events,  we use an EntryListener implementation to count the received
- * events.  The event we are generation and counting are:  add  remove  update  evict
- * as currently the event system of hazelcast is on a "best effort" basis  it is possible that  the number of generated
- * events for will not equals the number of events received, In the future the hz event system could change.  for now
- * we can say the number of events received can not be greater that an the number of events generated
+ * This test is using a map to generate map entry events. We use an {@link com.hazelcast.core.EntryListener} implementation to
+ * count the received events. We are generating and counting add, remove, update and evict events.
+ * <p/>
+ * As currently the event system of Hazelcast is on a "best effort" basis, it is possible that the number of generated events will
+ * not equal the number of events received. In the future the Hazelcast event system could change. For now we can say the number
+ * of events received can not be greater than the number of events generated.
  */
 public class MapEntryListenerTest {
 
-    private static final int SLEEP_MS_CATCH_EVENTS = 8000;
+    private enum Operation {
+        PUT,
+        EVICT,
+        REMOVE,
+        DELETE
+    }
 
-    private final static ILogger log = Logger.getLogger(MapEntryListenerTest.class);
+    private enum PutOperation {
+        PUT,
+        PUT_IF_ABSENT,
+        REPLACE
+    }
 
-    public String basename = this.getClass().getName();
+    private static final int SLEEP_CATCH_EVENTS_MILLIS = 8000;
+    private static final ILogger log = Logger.getLogger(MapEntryListenerTest.class);
+
+    // properties
+    public String basename = this.getClass().getSimpleName();
     public int threadCount = 3;
     public int valueLength = 100;
     public int keyCount = 1000;
@@ -59,153 +73,69 @@ public class MapEntryListenerTest {
     public int maxEntryListenerDelayMs = 0;
     public int minEntryListenerDelayMs = 0;
 
-    //check these add up to 1
-    public double writeProb = 0.4;
+    public double putProb = 0.4;
     public double evictProb = 0.2;
     public double removeProb = 0.2;
     public double deleteProb = 0.2;
 
-    //check these add up to 1   (writeProb is split up into sub styles)
-    public double writeUsingPutProb = 0.5;
-    public double writeUsingPutIfAbsent = 0.25;
-    public double replaceProb = 0.25;
+    public double putUsingPutIfAbsentProb = 0.25;
+    public double putUsingReplaceProb = 0.25;
+
+    private final ScrambledZipfianGenerator keysZipfian = new ScrambledZipfianGenerator(keyCount);
+    private final OperationSelectorBuilder<Operation> operationSelectorBuilder = new OperationSelectorBuilder<Operation>();
+    private final OperationSelectorBuilder<PutOperation> putOperationSelectorBuilder
+            = new OperationSelectorBuilder<PutOperation>();
 
     private String[] values;
-    private TestContext testContext;
-    private HazelcastInstance targetInstance;
-    private EntryListenerImpl listener;
-    private ScrambledZipfianGenerator kesyZipfian = new ScrambledZipfianGenerator(keyCount);
-    private IMap<Object, Object> map;
+    private EntryListenerImpl<Integer, String> listener;
+    private IList<EventCount> eventCounts;
+    private IList<EntryListenerImpl<Integer, String>> listeners;
+    private IMap<Integer, String> map;
 
     @Setup
     public void setup(TestContext testContext) throws Exception {
-        this.testContext = testContext;
-        targetInstance = testContext.getTargetInstance();
+        HazelcastInstance targetInstance = testContext.getTargetInstance();
+
         values = StringUtils.generateStrings(valueCount, valueLength);
+        listener = new EntryListenerImpl<Integer, String>(minEntryListenerDelayMs, maxEntryListenerDelayMs);
+
+        eventCounts = targetInstance.getList(basename + "eventCount");
+        listeners = targetInstance.getList(basename + "listeners");
 
         map = targetInstance.getMap(basename);
-        listener = new EntryListenerImpl(minEntryListenerDelayMs, maxEntryListenerDelayMs);
         map.addEntryListener(listener, true);
+
+        operationSelectorBuilder
+                .addOperation(Operation.PUT, putProb)
+                .addOperation(Operation.EVICT, evictProb)
+                .addOperation(Operation.REMOVE, removeProb)
+                .addOperation(Operation.DELETE, deleteProb);
+
+        putOperationSelectorBuilder
+                .addOperation(PutOperation.PUT_IF_ABSENT, putUsingPutIfAbsentProb)
+                .addOperation(PutOperation.REPLACE, putUsingReplaceProb)
+                .addDefaultOperation(PutOperation.PUT);
     }
 
     @Warmup(global = true)
     public void globalWarmup() {
-        IMap map = targetInstance.getMap(basename);
-
         EventCount initCounter = new EventCount();
 
-        int v = 0;
-        for (int k = 0; k < keyCount; k++) {
-            map.put(k, values[v]);
-            initCounter.localAddCount.getAndIncrement();
-            v = (v + 1 == values.length ? 0 : v + 1);
+        for (int i = 0; i < keyCount; i++) {
+            map.put(i, values[i % valueLength]);
+            initCounter.addCount.getAndIncrement();
         }
-        IList results = targetInstance.getList(basename + "eventCount");
-        results.add(initCounter);
-    }
 
-    @Run
-    public void run() {
-        ThreadSpawner spawner = new ThreadSpawner(testContext.getTestId());
-        for (int k = 0; k < threadCount; k++) {
-            spawner.spawn(new Worker());
-        }
-        spawner.awaitCompletion();
-
-        // wait, so that our entry listener implementation can catch the last incoming events from other members / clients
-        sleepMillis(SLEEP_MS_CATCH_EVENTS);
-
-        IList listeners = targetInstance.getList(basename + "listeners");
-        listeners.add(listener);
+        eventCounts.add(initCounter);
     }
 
     @Teardown(global = true)
     public void tearDown() throws Exception {
-        IMap map = targetInstance.getMap(basename);
         map.destroy();
-    }
-
-    private class Worker implements Runnable {
-        private EventCount eventCount = new EventCount();
-        private final Random random = new Random();
-        int key;
-
-        public void run() {
-            while (!testContext.isStopped()) {
-
-                if (randomDistributionUniform) {
-                    key = random.nextInt(keyCount);
-                } else {
-                    key = kesyZipfian.nextInt();
-                }
-
-                double chance = random.nextDouble();
-                if (chance < writeProb) {
-                    final Object value = values[random.nextInt(values.length)];
-
-                    chance = random.nextDouble();
-                    if (chance < writeUsingPutProb) {
-                        map.lock(key);
-                        try {
-                            if (map.containsKey(key)) {
-                                eventCount.localUpdateCount.getAndIncrement();
-                            } else {
-                                eventCount.localAddCount.getAndIncrement();
-                            }
-                            map.put(key, value);
-                        } finally {
-                            map.unlock(key);
-                        }
-                    } else if (chance < writeUsingPutIfAbsent + writeUsingPutProb) {
-                        map.lock(key);
-                        try {
-                            if (map.putIfAbsent(key, value) == null) {
-                                eventCount.localAddCount.getAndIncrement();
-                            }
-                        } finally {
-                            map.unlock(key);
-                        }
-                    } else if (chance < replaceProb + writeUsingPutIfAbsent + writeUsingPutProb) {
-                        Object orig = map.get(key);
-                        if (orig != null && map.replace(key, orig, value)) {
-                            eventCount.localUpdateCount.getAndIncrement();
-                        }
-                    }
-                } else if (chance < evictProb + writeProb) {
-                    map.lock(key);
-                    try {
-                        if (map.containsKey(key)) {
-                            eventCount.localEvictCount.getAndIncrement();
-                        }
-                        map.evict(key);
-                    } finally {
-                        map.unlock(key);
-                    }
-                } else if (chance < removeProb + evictProb + writeProb) {
-                    Object o = map.remove(key);
-                    if (o != null) {
-                        eventCount.localRemoveCount.getAndIncrement();
-                    }
-                } else if (chance < deleteProb + removeProb + evictProb + writeProb) {
-                    map.lock(key);
-                    try {
-                        if (map.containsKey(key)) {
-                            eventCount.localRemoveCount.getAndIncrement();
-                        }
-                        map.delete(key);
-                    } finally {
-                        map.unlock(key);
-                    }
-                }
-            }
-            IList results = targetInstance.getList(basename + "eventCount");
-            results.add(eventCount);
-        }
     }
 
     @Verify(global = true)
     public void globalVerify() throws Exception {
-        IList<EntryListenerImpl> listeners = targetInstance.getList(basename + "listeners");
         for (int i = 0; i < listeners.size() - 1; i++) {
             EntryListenerImpl a = listeners.get(i);
             EntryListenerImpl b = listeners.get(i + 1);
@@ -215,20 +145,128 @@ public class MapEntryListenerTest {
 
     @Verify(global = false)
     public void verify() throws Exception {
-        IList<EventCount> eventCounts = targetInstance.getList(basename + "eventCount");
         EventCount total = new EventCount();
-        for (EventCount c : eventCounts) {
-            total.add(c);
+        for (EventCount eventCount : eventCounts) {
+            total.add(eventCount);
         }
-        total.waiteWhileListenerEventsIncrease(listener, 10);
+        total.waitWhileListenerEventsIncrease(listener, 10);
 
-        log.info(basename + ": add = " + total.localAddCount.get() + " " + listener.addCount.get());
-        log.info(basename + ": update = " + total.localUpdateCount.get() + " " + listener.updateCount.get());
-        log.info(basename + ": remove = " + total.localRemoveCount.get() + " " + listener.removeCount.get());
-        log.info(basename + ": evict = " + total.localEvictCount.get() + " " + listener.evictCount.get());
-
-        log.info(basename + ": mapSZ = " + map.size() + " " + total.calculateMapSize() + " " + total.calculateMapSize(listener));
+        log.info("Event counter for " + basename + " (actual / expected)"
+                + "\nadd: " + listener.addCount.get() + " / " + total.addCount.get()
+                + "\nupdate: " + listener.updateCount.get() + " / " + total.updateCount.get()
+                + "\nremove: " + listener.removeCount.get() + " / " + total.removeCount.get()
+                + "\nevict: " + listener.evictCount.get() + " / " + total.evictCount.get()
+                + "\nmapSize: " + total.calculateMapSize(listener) + " / " + total.calculateMapSize());
 
         total.assertEventsEquals(listener);
+    }
+
+    @RunWithWorker
+    public AbstractWorkerTask<Operation> createWorker() {
+        return new Worker();
+    }
+
+    private class Worker extends AbstractWorkerTask<Operation> {
+
+        private final EventCount eventCount = new EventCount();
+        private final OperationSelector<PutOperation> putSelector = putOperationSelectorBuilder.build();
+
+        public Worker() {
+            super(operationSelectorBuilder);
+        }
+
+        @Override
+        protected void timeStep(Operation operation) {
+            int key;
+
+            if (randomDistributionUniform) {
+                key = randomInt(keyCount);
+            } else {
+                key = keysZipfian.nextInt();
+            }
+
+            switch (operation) {
+                case PUT:
+                    String value = values[randomInt(values.length)];
+
+                    switch (putSelector.select()) {
+                        case PUT:
+                            map.lock(key);
+                            try {
+                                if (map.containsKey(key)) {
+                                    eventCount.updateCount.getAndIncrement();
+                                } else {
+                                    eventCount.addCount.getAndIncrement();
+                                }
+                                map.put(key, value);
+                            } finally {
+                                map.unlock(key);
+                            }
+                            break;
+                        case PUT_IF_ABSENT:
+                            map.lock(key);
+                            try {
+                                if (map.putIfAbsent(key, value) == null) {
+                                    eventCount.addCount.getAndIncrement();
+                                }
+                            } finally {
+                                map.unlock(key);
+                            }
+                            break;
+                        case REPLACE:
+                            String oldValue = map.get(key);
+                            if (oldValue != null && map.replace(key, oldValue, value)) {
+                                eventCount.updateCount.getAndIncrement();
+                            }
+                            break;
+                        default:
+                            throw new UnsupportedOperationException();
+                    }
+                    break;
+                case EVICT:
+                    map.lock(key);
+                    try {
+                        if (map.containsKey(key)) {
+                            eventCount.evictCount.getAndIncrement();
+                        }
+                        map.evict(key);
+                    } finally {
+                        map.unlock(key);
+                    }
+                    break;
+                case REMOVE:
+                    String oldValue = map.remove(key);
+                    if (oldValue != null) {
+                        eventCount.removeCount.getAndIncrement();
+                    }
+                    break;
+                case DELETE:
+                    map.lock(key);
+                    try {
+                        if (map.containsKey(key)) {
+                            eventCount.removeCount.getAndIncrement();
+                        }
+                        map.delete(key);
+                    } finally {
+                        map.unlock(key);
+                    }
+                    break;
+                default:
+                    throw new UnsupportedOperationException();
+            }
+        }
+
+        @Override
+        protected void afterRun() {
+            eventCounts.add(eventCount);
+        }
+
+        @Override
+        public void afterCompletion() {
+            // wait, so that our entry listener implementation can catch the last incoming events from other members / clients
+            sleepMillis(SLEEP_CATCH_EVENTS_MILLIS);
+
+            listeners.add(listener);
+        }
     }
 }

--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/map/helpers/EventCount.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/map/helpers/EventCount.java
@@ -7,101 +7,99 @@ import com.hazelcast.nio.serialization.DataSerializable;
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicLong;
 
+import static com.hazelcast.stabilizer.utils.CommonUtils.sleepSeconds;
 import static org.junit.Assert.assertEquals;
 
 public class EventCount implements DataSerializable {
-    public AtomicLong localAddCount = new AtomicLong(0);
-    public AtomicLong localRemoveCount = new AtomicLong(0);
-    public AtomicLong localUpdateCount = new AtomicLong(0);
-    public AtomicLong localEvictCount = new AtomicLong(0);
+    public AtomicLong addCount = new AtomicLong(0);
+    public AtomicLong removeCount = new AtomicLong(0);
+    public AtomicLong updateCount = new AtomicLong(0);
+    public AtomicLong evictCount = new AtomicLong(0);
 
     public EventCount() {
     }
 
-    public void add(EventCount c) {
-        localAddCount.addAndGet(c.localAddCount.get());
-        localRemoveCount.addAndGet(c.localRemoveCount.get());
-        localUpdateCount.addAndGet(c.localUpdateCount.get());
-        localEvictCount.addAndGet(c.localEvictCount.get());
-    }
-
-    public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeObject(localAddCount);
-        out.writeObject(localRemoveCount);
-        out.writeObject(localUpdateCount);
-        out.writeObject(localEvictCount);
-    }
-
-    public void readData(ObjectDataInput in) throws IOException {
-        localAddCount = in.readObject();
-        localRemoveCount = in.readObject();
-        localUpdateCount = in.readObject();
-        localEvictCount = in.readObject();
-    }
-
-    public long total() {
-        return localAddCount.get() +
-                localRemoveCount.get() +
-                localUpdateCount.get() +
-                localEvictCount.get();
-    }
-
-    public long absDifference(EntryListenerImpl e) {
-        long countTotal = total();
-
-        Long listenerTotal = e.addCount.get() +
-                e.updateCount.get() +
-                e.removeCount.get() +
-                e.evictCount.get();
-
-        return Math.abs(countTotal - listenerTotal);
-    }
-
-    public boolean sameEventCount(EntryListenerImpl listener) {
-        return absDifference(listener) == 0;
-    }
-
-    public void waiteWhileListenerEventsIncrease(EntryListenerImpl listener, int maxIterationNoChange) throws InterruptedException {
-        int noChange = 0;
-        long prev = 0;
-        do {
-            long diff = absDifference(listener);
-
-            if (diff >= prev) {
-                noChange++;
-            } else {
-                noChange = 0;
-            }
-            prev = diff;
-
-            Thread.sleep(2000);
-
-        } while (!sameEventCount(listener) && noChange < maxIterationNoChange);
+    public void add(EventCount eventCount) {
+        addCount.addAndGet(eventCount.addCount.get());
+        removeCount.addAndGet(eventCount.removeCount.get());
+        updateCount.addAndGet(eventCount.updateCount.get());
+        evictCount.addAndGet(eventCount.evictCount.get());
     }
 
     public long calculateMapSize() {
-        return localAddCount.get() - (localEvictCount.get() + localRemoveCount.get());
+        return addCount.get() - (evictCount.get() + removeCount.get());
     }
 
     public long calculateMapSize(EntryListenerImpl listener) {
         return listener.addCount.get() - (listener.evictCount.get() + listener.removeCount.get());
     }
 
+    public void waitWhileListenerEventsIncrease(EntryListenerImpl listener, int maxIterationNoChange) {
+        int iterationsWithoutChange = 0;
+        long prev = 0;
+        do {
+            long diff = absDifference(listener);
+
+            if (diff >= prev) {
+                iterationsWithoutChange++;
+            } else {
+                iterationsWithoutChange = 0;
+            }
+            prev = diff;
+
+            sleepSeconds(2);
+        } while (!sameEventCount(listener) && iterationsWithoutChange < maxIterationNoChange);
+    }
+
+    public boolean sameEventCount(EntryListenerImpl listener) {
+        return (absDifference(listener) == 0);
+    }
+
+    private long absDifference(EntryListenerImpl listener) {
+        Long listenerTotal = listener.addCount.get()
+                + listener.updateCount.get()
+                + listener.removeCount.get()
+                + listener.evictCount.get();
+
+        return Math.abs(total() - listenerTotal);
+    }
+
+    private long total() {
+        return addCount.get()
+                + removeCount.get()
+                + updateCount.get()
+                + evictCount.get();
+    }
+
     public void assertEventsEquals(EntryListenerImpl listener) {
-        assertEquals("Add Events ", localAddCount.get(), listener.addCount.get());
-        assertEquals("Update Events ", localUpdateCount.get(), listener.updateCount.get());
-        assertEquals("Remove Events ", localRemoveCount.get(), listener.removeCount.get());
-        assertEquals("Evict Events ", localEvictCount.get(), listener.evictCount.get());
-        assertEquals("calculated Map size", calculateMapSize(), calculateMapSize(listener));
+        assertEquals("Add Events ", addCount.get(), listener.addCount.get());
+        assertEquals("Update Events ", updateCount.get(), listener.updateCount.get());
+        assertEquals("Remove Events ", removeCount.get(), listener.removeCount.get());
+        assertEquals("Evict Events ", evictCount.get(), listener.evictCount.get());
+        assertEquals("calculated Map size ", calculateMapSize(), calculateMapSize(listener));
     }
 
     @Override
     public String toString() {
         return "Count{"
-                + "putCount=" + localAddCount
-                + ", putTransientCount=" + localRemoveCount
-                + ", putIfAbsentCount=" + localUpdateCount
-                + ", replaceCount=" + localEvictCount
+                + "putCount=" + addCount
+                + ", putTransientCount=" + removeCount
+                + ", putIfAbsentCount=" + updateCount
+                + ", replaceCount=" + evictCount
                 + '}';
+    }
+
+    public void writeData(ObjectDataOutput out) throws IOException {
+        out.writeObject(addCount);
+        out.writeObject(removeCount);
+        out.writeObject(updateCount);
+        out.writeObject(evictCount);
+    }
+
+    public void readData(ObjectDataInput in) throws IOException {
+        addCount = in.readObject();
+        removeCount = in.readObject();
+        updateCount = in.readObject();
+        evictCount = in.readObject();
     }
 }


### PR DESCRIPTION
* Cleanup of `MapEntryListenerTest`
* Introducing the method `AbstractWorkerTask.afterCompletion()` which is executed once after all workers are done