### PR TITLE
Cleanup of MapMaxSizeTest

### DIFF
--- a/dist/src/main/dist/conf/hazelcast.xml
+++ b/dist/src/main/dist/conf/hazelcast.xml
@@ -27,12 +27,13 @@
         </map-store>
     </map>
 
-    <map name="MaxSizeMap*">
+    <map name="MapMaxSize*">
         <eviction-policy>LRU</eviction-policy>
         <max-size policy="PER_NODE">1000</max-size>
         <eviction-percentage>25</eviction-percentage>
         <min-eviction-check-millis>0</min-eviction-check-millis>
     </map>
+
 
     <map name="NoBackup*">
         <backup-count>0</backup-count>

--- a/dist/src/main/dist/stabilizer-tests/test.properties
+++ b/dist/src/main/dist/stabilizer-tests/test.properties
@@ -1,4 +1,3 @@
-
 MapCasTest@class=com.hazelcast.stabilizer.tests.map.MapCasTest
 MapCasTest@threadCount=3
 MapCasTest@keyCount=1000
@@ -105,16 +104,13 @@ lockConflict@tryLockTimeOutMs=10
 lockConflict@throwException=false
 lockConflict@basename=lockConflict
 
-MaxSizeMap@class=com.hazelcast.stabilizer.tests.map.MapMaxSizeTest
-MaxSizeMap@threadCount=3
-MaxSizeMap@keyCount=1000000
-MaxSizeMap@writeProb=0.7
-MaxSizeMap@getProb=0
-MaxSizeMap@checkSizeProb=0.3
-MaxSizeMap@writeUsingPutProb=0.6
-MaxSizeMap@writeUsingPutAsyncProb=0.4
-MaxSizeMap@basename=MaxSizeMap1
-
+MapMaxSize@class=com.hazelcast.stabilizer.tests.map.MapMaxSizeTest
+MapMaxSize@threadCount=3
+MapMaxSize@keyCount=1000000
+MapMaxSize@putProb=0.7
+MapMaxSize@getProb=0.0
+MapMaxSize@checkProb=0.3
+MapMaxSize@putUsingAsyncProb=0.4
 
 #waiting result on issue https://github.com/hazelcast/hazelcast/issues/4364
 #txnConflict@class=com.hazelcast.stabilizer.tests.map.MapTransactionContextConflictTest

--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/test/utils/TestUtils.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/test/utils/TestUtils.java
@@ -23,9 +23,9 @@ import org.apache.log4j.Logger;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
-import static com.hazelcast.stabilizer.utils.CommonUtils.sleepMillis;
 import static com.hazelcast.stabilizer.utils.CommonUtils.sleepMillisThrowException;
 import static java.lang.String.format;
+import static org.junit.Assert.assertEquals;
 
 public class TestUtils {
 
@@ -62,6 +62,18 @@ public class TestUtils {
         }
 
         logger.info("Partitions are warmed up successfully");
+    }
+
+    /**
+     * This method executes the normal assertEquals with expected and actual values.
+     * In addition it formats the given string with those values to provide a good assert message.
+     *
+     * @param message     assert message which is formatted with expected and actual values
+     * @param expected    expected value which is used for assert
+     * @param actual      actual value which is used for assert
+     */
+    public static void assertEqualsStringFormat(String message, Object expected, Object actual) {
+        assertEquals(String.format(message, expected, actual), expected, actual);
     }
 
     /**


### PR DESCRIPTION
* Checked the actual `MaxSizeConfig` during setup phase (fail fast).
* Retrieved the max size per node from configuration (to get rid of the hard coded `1000` in the test).
* Also removed the `@Verify(global = false)` method (config is printed in the setup method now).
* Changed the configuration map name from `MaxSizeMap` to `MapMaxSize`, so it matches the test name automatically.
* Added the `assertEqualsStringFormat` method from `HazelcastTestSupport` to create verbose assert messages more easily (was used during refactoring, will be useful for other tests).