### PR TITLE
Renamed AbstractWorkerTask to AbstractWorker

### DIFF
--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/worker/tasks/AbstractAsyncWorker.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/worker/tasks/AbstractAsyncWorker.java
@@ -5,17 +5,17 @@ import com.hazelcast.stabilizer.utils.ExceptionReporter;
 import com.hazelcast.stabilizer.worker.selector.OperationSelectorBuilder;
 
 /**
- * Asynchronous version of {@link AbstractWorkerTask}.
+ * Asynchronous version of {@link AbstractWorker}.
  * <p/>
  * The operation counter is automatically increased after call of {@link com.hazelcast.core.ExecutionCallback#onResponse}.
  *
  * @param <O> Type of Enum used by the {@link com.hazelcast.stabilizer.worker.selector.OperationSelector}
  * @param <V> Type of {@link com.hazelcast.core.ExecutionCallback}
  */
-public abstract class AbstractAsyncWorkerTask<O extends Enum<O>, V> extends AbstractWorkerTask<O>
+public abstract class AbstractAsyncWorker<O extends Enum<O>, V> extends AbstractWorker<O>
         implements ExecutionCallback<V> {
 
-    public AbstractAsyncWorkerTask(OperationSelectorBuilder<O> operationSelectorBuilder) {
+    public AbstractAsyncWorker(OperationSelectorBuilder<O> operationSelectorBuilder) {
         super(operationSelectorBuilder);
     }
 

--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/worker/tasks/AbstractMonotonicWorker.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/worker/tasks/AbstractMonotonicWorker.java
@@ -1,12 +1,12 @@
 package com.hazelcast.stabilizer.worker.tasks;
 
 /**
- * Monotonic version of {@link AbstractWorkerTask}.
+ * Monotonic version of {@link AbstractWorker}.
  * <p/>
  * This worker provides no {@link com.hazelcast.stabilizer.worker.selector.OperationSelector}, just a simple {@link #timeStep()}
  * method without parameters.
  */
-public abstract class AbstractMonotonicWorkerTask extends AbstractWorkerTask {
+public abstract class AbstractMonotonicWorker extends AbstractWorker {
 
     @Override
     public final void run() {

--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/worker/tasks/AbstractWorker.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/worker/tasks/AbstractWorker.java
@@ -20,9 +20,9 @@ import java.util.concurrent.atomic.AtomicLong;
  *
  * @param <O> Type of Enum used by the {@link com.hazelcast.stabilizer.worker.selector.OperationSelector}
  */
-public abstract class AbstractWorkerTask<O extends Enum<O>> implements Runnable {
+public abstract class AbstractWorker<O extends Enum<O>> implements Runnable {
 
-    final static ILogger LOGGER = Logger.getLogger(AbstractWorkerTask.class);
+    final static ILogger LOGGER = Logger.getLogger(AbstractWorker.class);
 
     final Random random = new Random();
     final OperationSelector<O> selector;
@@ -38,14 +38,14 @@ public abstract class AbstractWorkerTask<O extends Enum<O>> implements Runnable 
     // local variables
     long iteration = 0;
 
-    public AbstractWorkerTask(OperationSelectorBuilder<O> operationSelectorBuilder) {
+    public AbstractWorker(OperationSelectorBuilder<O> operationSelectorBuilder) {
         this.selector = operationSelectorBuilder.build();
     }
 
     /**
      * This constructor is just for child classes who also override the {@link #run()} method.
      */
-    AbstractWorkerTask() {
+    AbstractWorker() {
         this.selector = null;
     }
 

--- a/stabilizer/src/test/java/com/hazelcast/stabilizer/worker/TestContainerTest.java
+++ b/stabilizer/src/test/java/com/hazelcast/stabilizer/worker/TestContainerTest.java
@@ -17,7 +17,7 @@ import com.hazelcast.stabilizer.test.annotations.Run;
 import com.hazelcast.stabilizer.test.annotations.Setup;
 import com.hazelcast.stabilizer.test.annotations.Verify;
 import com.hazelcast.stabilizer.worker.selector.OperationSelectorBuilder;
-import com.hazelcast.stabilizer.worker.tasks.AbstractWorkerTask;
+import com.hazelcast.stabilizer.worker.tasks.AbstractWorker;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -66,7 +66,7 @@ public class TestContainerTest {
         }
 
         @RunWithWorker
-        public AbstractWorkerTask createWorker() {
+        public AbstractWorker createWorker() {
             return null;
         }
     }
@@ -148,8 +148,8 @@ public class TestContainerTest {
     }
 
     @Test
-    public void testRunWithBaseWorker() throws Throwable {
-        RunWithBaseWorkerTest test = new RunWithBaseWorkerTest();
+    public void testRunWithWorker() throws Throwable {
+        RunWithWorkerTest test = new RunWithWorkerTest();
         invoker = new TestContainer<DummyTestContext>(test, testContext, probesConfiguration);
         new Thread() {
             @Override
@@ -164,7 +164,7 @@ public class TestContainerTest {
         assertTrue(test.runWithWorkerCalled);
     }
 
-    private static class RunWithBaseWorkerTest {
+    private static class RunWithWorkerTest {
         private enum Operation {
             NOP
         }
@@ -175,8 +175,8 @@ public class TestContainerTest {
         boolean runWithWorkerCalled;
 
         @RunWithWorker
-        AbstractWorkerTask<Operation> createWorker() {
-            return new AbstractWorkerTask<Operation>(builder) {
+        AbstractWorker<Operation> createWorker() {
+            return new AbstractWorker<Operation>(builder) {
                 @Override
                 protected void timeStep(Operation operation) {
                     runWithWorkerCalled = true;

--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/map/IntIntMapTest.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/map/IntIntMapTest.java
@@ -29,7 +29,7 @@ import com.hazelcast.stabilizer.test.annotations.Warmup;
 import com.hazelcast.stabilizer.tests.helpers.KeyLocality;
 import com.hazelcast.stabilizer.tests.helpers.KeyUtils;
 import com.hazelcast.stabilizer.worker.selector.OperationSelectorBuilder;
-import com.hazelcast.stabilizer.worker.tasks.AbstractWorkerTask;
+import com.hazelcast.stabilizer.worker.tasks.AbstractWorker;
 
 import java.util.Random;
 
@@ -96,13 +96,13 @@ public class IntIntMapTest {
     }
 
     @RunWithWorker
-    public AbstractWorkerTask<Operation> createWorker() {
-        return new WorkerTask();
+    public AbstractWorker<Operation> createWorker() {
+        return new Worker();
     }
 
-    private class WorkerTask extends AbstractWorkerTask<Operation> {
+    private class Worker extends AbstractWorker<Operation> {
 
-        public WorkerTask() {
+        public Worker() {
             super(operationSelectorBuilder);
         }
 

--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/map/MapAsyncOpsTest.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/map/MapAsyncOpsTest.java
@@ -12,7 +12,7 @@ import com.hazelcast.stabilizer.test.annotations.Setup;
 import com.hazelcast.stabilizer.test.annotations.Verify;
 import com.hazelcast.stabilizer.tests.map.helpers.MapOperationCounter;
 import com.hazelcast.stabilizer.worker.selector.OperationSelectorBuilder;
-import com.hazelcast.stabilizer.worker.tasks.AbstractWorkerTask;
+import com.hazelcast.stabilizer.worker.tasks.AbstractWorker;
 
 import java.util.concurrent.TimeUnit;
 
@@ -76,12 +76,12 @@ public class MapAsyncOpsTest {
     }
 
     @RunWithWorker
-    public AbstractWorkerTask<Operation> createWorker() {
-        return new WorkerTask();
+    public AbstractWorker<Operation> createWorker() {
+        return new Worker();
     }
 
-    private class WorkerTask extends AbstractWorkerTask<Operation> {
-        public WorkerTask() {
+    private class Worker extends AbstractWorker<Operation> {
+        public Worker() {
             super(operationSelectorBuilder);
         }
 

--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/map/MapCasTest.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/map/MapCasTest.java
@@ -9,8 +9,8 @@ import com.hazelcast.stabilizer.test.annotations.Setup;
 import com.hazelcast.stabilizer.test.annotations.Teardown;
 import com.hazelcast.stabilizer.test.annotations.Verify;
 import com.hazelcast.stabilizer.test.annotations.Warmup;
-import com.hazelcast.stabilizer.worker.tasks.AbstractWorkerTask;
-import com.hazelcast.stabilizer.worker.tasks.AbstractMonotonicWorkerTask;
+import com.hazelcast.stabilizer.worker.tasks.AbstractWorker;
+import com.hazelcast.stabilizer.worker.tasks.AbstractMonotonicWorker;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -81,11 +81,11 @@ public class MapCasTest {
     }
 
     @RunWithWorker
-    public AbstractWorkerTask createWorker() {
-        return new WorkerTask();
+    public AbstractWorker createWorker() {
+        return new Worker();
     }
 
-    private class WorkerTask extends AbstractMonotonicWorkerTask {
+    private class Worker extends AbstractMonotonicWorker {
         private final Map<Integer, Long> result = new HashMap<Integer, Long>();
 
         protected void beforeRun() {

--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/map/MapEntryListenerTest.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/map/MapEntryListenerTest.java
@@ -32,7 +32,7 @@ import com.hazelcast.stabilizer.tests.map.helpers.EntryListenerImpl;
 import com.hazelcast.stabilizer.tests.map.helpers.ScrambledZipfianGenerator;
 import com.hazelcast.stabilizer.worker.selector.OperationSelector;
 import com.hazelcast.stabilizer.worker.selector.OperationSelectorBuilder;
-import com.hazelcast.stabilizer.worker.tasks.AbstractWorkerTask;
+import com.hazelcast.stabilizer.worker.tasks.AbstractWorker;
 
 import static com.hazelcast.stabilizer.utils.CommonUtils.sleepMillis;
 import static org.junit.Assert.assertEquals;
@@ -162,11 +162,11 @@ public class MapEntryListenerTest {
     }
 
     @RunWithWorker
-    public AbstractWorkerTask<MapOperation> createWorker() {
+    public AbstractWorker<MapOperation> createWorker() {
         return new Worker();
     }
 
-    private class Worker extends AbstractWorkerTask<MapOperation> {
+    private class Worker extends AbstractWorker<MapOperation> {
 
         private final EventCount eventCount = new EventCount();
         private final OperationSelector<MapPutOperation> mapPutSelector = mapPutOperationSelectorBuilder.build();

--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/map/MapEntryProcessorTest.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/map/MapEntryProcessorTest.java
@@ -16,8 +16,8 @@ import com.hazelcast.stabilizer.test.annotations.Verify;
 import com.hazelcast.stabilizer.test.annotations.Warmup;
 import com.hazelcast.stabilizer.tests.helpers.KeyLocality;
 import com.hazelcast.stabilizer.tests.helpers.KeyUtils;
-import com.hazelcast.stabilizer.worker.tasks.AbstractMonotonicWorkerTask;
-import com.hazelcast.stabilizer.worker.tasks.AbstractWorkerTask;
+import com.hazelcast.stabilizer.worker.tasks.AbstractMonotonicWorker;
+import com.hazelcast.stabilizer.worker.tasks.AbstractWorker;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -92,11 +92,11 @@ public class MapEntryProcessorTest {
     }
 
     @RunWithWorker
-    public AbstractWorkerTask createWorker() {
+    public AbstractWorker createWorker() {
         return new Worker();
     }
 
-    private class Worker extends AbstractMonotonicWorkerTask {
+    private class Worker extends AbstractMonotonicWorker {
         private final Map<Integer, Long> result = new HashMap<Integer, Long>();
 
         @Override

--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/map/MapLockTest.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/map/MapLockTest.java
@@ -10,8 +10,8 @@ import com.hazelcast.stabilizer.test.annotations.RunWithWorker;
 import com.hazelcast.stabilizer.test.annotations.Setup;
 import com.hazelcast.stabilizer.test.annotations.Verify;
 import com.hazelcast.stabilizer.test.annotations.Warmup;
-import com.hazelcast.stabilizer.worker.tasks.AbstractMonotonicWorkerTask;
-import com.hazelcast.stabilizer.worker.tasks.AbstractWorkerTask;
+import com.hazelcast.stabilizer.worker.tasks.AbstractMonotonicWorker;
+import com.hazelcast.stabilizer.worker.tasks.AbstractWorker;
 
 import static java.lang.String.format;
 import static org.junit.Assert.assertEquals;
@@ -72,11 +72,11 @@ public class MapLockTest {
     }
 
     @RunWithWorker
-    public AbstractWorkerTask createWorker() {
+    public AbstractWorker createWorker() {
         return new Worker();
     }
 
-    private class Worker extends AbstractMonotonicWorkerTask {
+    private class Worker extends AbstractMonotonicWorker {
         private final long[] increments = new long[keyCount];
 
         @Override

--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/map/MapLongPerformanceTest.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/map/MapLongPerformanceTest.java
@@ -12,7 +12,7 @@ import com.hazelcast.stabilizer.test.annotations.Setup;
 import com.hazelcast.stabilizer.test.annotations.Teardown;
 import com.hazelcast.stabilizer.test.annotations.Warmup;
 import com.hazelcast.stabilizer.worker.selector.OperationSelectorBuilder;
-import com.hazelcast.stabilizer.worker.tasks.AbstractWorkerTask;
+import com.hazelcast.stabilizer.worker.tasks.AbstractWorker;
 
 public class MapLongPerformanceTest {
 
@@ -64,11 +64,11 @@ public class MapLongPerformanceTest {
     }
 
     @RunWithWorker
-    public AbstractWorkerTask<Operation> createWorker() {
+    public AbstractWorker<Operation> createWorker() {
         return new Worker();
     }
 
-    private class Worker extends AbstractWorkerTask<Operation> {
+    private class Worker extends AbstractWorker<Operation> {
 
         public Worker() {
             super(operationSelectorBuilder);

--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/map/MapMaxSizeTest.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/map/MapMaxSizeTest.java
@@ -14,7 +14,7 @@ import com.hazelcast.stabilizer.tests.map.helpers.MapMaxSizeOperationCounter;
 import com.hazelcast.stabilizer.utils.ExceptionReporter;
 import com.hazelcast.stabilizer.worker.selector.OperationSelector;
 import com.hazelcast.stabilizer.worker.selector.OperationSelectorBuilder;
-import com.hazelcast.stabilizer.worker.tasks.AbstractWorkerTask;
+import com.hazelcast.stabilizer.worker.tasks.AbstractWorker;
 
 import static com.hazelcast.config.MaxSizeConfig.MaxSizePolicy.PER_NODE;
 import static com.hazelcast.stabilizer.test.utils.TestUtils.assertEqualsStringFormat;
@@ -111,11 +111,11 @@ public class MapMaxSizeTest {
     }
 
     @RunWithWorker
-    public AbstractWorkerTask<MapOperation> createWorker() {
+    public AbstractWorker<MapOperation> createWorker() {
         return new Worker();
     }
 
-    private class Worker extends AbstractWorkerTask<MapOperation> {
+    private class Worker extends AbstractWorker<MapOperation> {
         private final MapMaxSizeOperationCounter operationCounter = new MapMaxSizeOperationCounter();
         private final OperationSelector<MapPutOperation> mapPutSelector = mapPutOperationSelectorBuilder.build();
 

--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/map/MapPredicateTest.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/map/MapPredicateTest.java
@@ -19,7 +19,7 @@ import com.hazelcast.stabilizer.test.annotations.Warmup;
 import com.hazelcast.stabilizer.tests.map.helpers.Employee;
 import com.hazelcast.stabilizer.tests.map.helpers.PredicateOperationCounter;
 import com.hazelcast.stabilizer.worker.selector.OperationSelectorBuilder;
-import com.hazelcast.stabilizer.worker.tasks.AbstractWorkerTask;
+import com.hazelcast.stabilizer.worker.tasks.AbstractWorker;
 
 import java.util.Collection;
 
@@ -96,11 +96,11 @@ public class MapPredicateTest {
     }
 
     @RunWithWorker
-    public AbstractWorkerTask<Operation> createWorker() {
+    public AbstractWorker<Operation> createWorker() {
         return new Worker();
     }
 
-    private class Worker extends AbstractWorkerTask<Operation> {
+    private class Worker extends AbstractWorker<Operation> {
         private final PredicateOperationCounter operationCounter = new PredicateOperationCounter();
 
         public Worker() {

--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/map/MapRaceTest.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/map/MapRaceTest.java
@@ -9,8 +9,8 @@ import com.hazelcast.stabilizer.test.annotations.Setup;
 import com.hazelcast.stabilizer.test.annotations.Teardown;
 import com.hazelcast.stabilizer.test.annotations.Verify;
 import com.hazelcast.stabilizer.test.annotations.Warmup;
-import com.hazelcast.stabilizer.worker.tasks.AbstractMonotonicWorkerTask;
-import com.hazelcast.stabilizer.worker.tasks.AbstractWorkerTask;
+import com.hazelcast.stabilizer.worker.tasks.AbstractMonotonicWorker;
+import com.hazelcast.stabilizer.worker.tasks.AbstractWorker;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -75,11 +75,11 @@ public class MapRaceTest {
     }
 
     @RunWithWorker
-    public AbstractWorkerTask createWorker() {
+    public AbstractWorker createWorker() {
         return new Worker();
     }
 
-    private class Worker extends AbstractMonotonicWorkerTask {
+    private class Worker extends AbstractMonotonicWorker {
         private final Map<Integer, Long> result = new HashMap<Integer, Long>();
 
         @Override

--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/map/MapReduceTest.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/map/MapReduceTest.java
@@ -24,7 +24,7 @@ import com.hazelcast.stabilizer.test.annotations.Warmup;
 import com.hazelcast.stabilizer.tests.map.helpers.Employee;
 import com.hazelcast.stabilizer.tests.map.helpers.MapReduceOperationCounter;
 import com.hazelcast.stabilizer.worker.selector.OperationSelectorBuilder;
-import com.hazelcast.stabilizer.worker.tasks.AbstractWorkerTask;
+import com.hazelcast.stabilizer.worker.tasks.AbstractWorker;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -86,11 +86,11 @@ public class MapReduceTest {
     }
 
     @RunWithWorker
-    public AbstractWorkerTask<Operation> createWorker() {
+    public AbstractWorker<Operation> createWorker() {
         return new Worker();
     }
 
-    private class Worker extends AbstractWorkerTask<Operation> {
+    private class Worker extends AbstractWorker<Operation> {
         private final MapReduceOperationCounter operationCounter = new MapReduceOperationCounter();
 
         public Worker() {

--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/map/StringStringMapTest.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/map/StringStringMapTest.java
@@ -30,7 +30,7 @@ import com.hazelcast.stabilizer.tests.helpers.KeyLocality;
 import com.hazelcast.stabilizer.tests.helpers.KeyUtils;
 import com.hazelcast.stabilizer.tests.helpers.StringUtils;
 import com.hazelcast.stabilizer.worker.selector.OperationSelectorBuilder;
-import com.hazelcast.stabilizer.worker.tasks.AbstractWorkerTask;
+import com.hazelcast.stabilizer.worker.tasks.AbstractWorker;
 
 import java.util.Random;
 
@@ -99,13 +99,13 @@ public class StringStringMapTest {
     }
 
     @RunWithWorker
-    public AbstractWorkerTask<Operation> createWorker() {
-        return new WorkerTask();
+    public AbstractWorker<Operation> createWorker() {
+        return new Worker();
     }
 
-    private class WorkerTask extends AbstractWorkerTask<Operation> {
+    private class Worker extends AbstractWorker<Operation> {
 
-        public WorkerTask() {
+        public Worker() {
             super(operationSelectorBuilder);
         }
 

--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/slow/SlowOperationMapTest.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/slow/SlowOperationMapTest.java
@@ -17,7 +17,7 @@ import com.hazelcast.stabilizer.tests.helpers.KeyLocality;
 import com.hazelcast.stabilizer.tests.helpers.KeyUtils;
 import com.hazelcast.stabilizer.utils.ExceptionReporter;
 import com.hazelcast.stabilizer.worker.selector.OperationSelectorBuilder;
-import com.hazelcast.stabilizer.worker.tasks.AbstractWorkerTask;
+import com.hazelcast.stabilizer.worker.tasks.AbstractWorker;
 
 import java.lang.reflect.Method;
 import java.util.Collection;
@@ -125,13 +125,13 @@ public class SlowOperationMapTest {
     }
 
     @RunWithWorker
-    public AbstractWorkerTask<Operation> createWorker() {
-        return new WorkerTask();
+    public AbstractWorker<Operation> createWorker() {
+        return new Worker();
     }
 
-    private class WorkerTask extends AbstractWorkerTask<Operation> {
+    private class Worker extends AbstractWorker<Operation> {
 
-        public WorkerTask() {
+        public Worker() {
             super(operationSelectorBuilder);
         }
 

--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/syntheticmap/StringStringSyntheticMapTest.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/syntheticmap/StringStringSyntheticMapTest.java
@@ -15,7 +15,7 @@ import com.hazelcast.stabilizer.tests.helpers.KeyLocality;
 import com.hazelcast.stabilizer.tests.helpers.KeyUtils;
 import com.hazelcast.stabilizer.tests.helpers.StringUtils;
 import com.hazelcast.stabilizer.worker.selector.OperationSelectorBuilder;
-import com.hazelcast.stabilizer.worker.tasks.AbstractWorkerTask;
+import com.hazelcast.stabilizer.worker.tasks.AbstractWorker;
 
 import java.util.Random;
 
@@ -83,13 +83,13 @@ public class StringStringSyntheticMapTest {
     }
 
     @RunWithWorker
-    public AbstractWorkerTask<Operation> createWorker() {
-        return new WorkerTask();
+    public AbstractWorker<Operation> createWorker() {
+        return new Worker();
     }
 
-    private class WorkerTask extends AbstractWorkerTask<Operation> {
+    private class Worker extends AbstractWorker<Operation> {
 
-        public WorkerTask() {
+        public Worker() {
             super(operationSelectorBuilder);
         }
 


### PR DESCRIPTION
Renamed `AbstractWorkerTask` to `AbstractWorker`, same for child classes. Renamed forgotten `BaseWorkerTask` named methods, variables and tests.