### PR TITLE
Cleanup of Class.getName() method calls

### DIFF
--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/agent/Agent.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/agent/Agent.java
@@ -36,7 +36,7 @@ import static java.lang.String.format;
 
 public class Agent {
 
-    private final static Logger log = Logger.getLogger(Coordinator.class.getName());
+    private final static Logger log = Logger.getLogger(Coordinator.class);
 
     public final static File STABILIZER_HOME = getStablizerHome();
 

--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/agent/HarakiriMonitor.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/agent/HarakiriMonitor.java
@@ -12,7 +12,7 @@ import static java.lang.String.format;
  * Responsible for terminating ec2-instances if they are not used to prevent running into a big bill.
  */
 public class HarakiriMonitor extends Thread {
-    private final static Logger log = Logger.getLogger(HarakiriMonitor.class.getName());
+    private final static Logger log = Logger.getLogger(HarakiriMonitor.class);
     private final Agent agent;
 
     public HarakiriMonitor(Agent agent) {
@@ -47,7 +47,7 @@ public class HarakiriMonitor extends Thread {
                     log.info("harakiri command: " + cmd);
                     bash.execute(cmd);
                 } catch (RuntimeException e) {
-                    log.info("Failed to execute harikiri");
+                    log.info("Failed to execute Harakiri");
                 }
                 return;
             }

--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/agent/remoting/AgentRemoteService.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/agent/remoting/AgentRemoteService.java
@@ -29,7 +29,7 @@ public class AgentRemoteService {
         SERVICE_PROCESS_MESSAGE
     }
 
-    private final static Logger log = Logger.getLogger(AgentRemoteService.class.getName());
+    private final static Logger log = Logger.getLogger(AgentRemoteService.class);
 
     final private Agent agent;
     final private AgentMessageProcessor agentMessageProcessor;

--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/common/messaging/MessagesFactory.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/common/messaging/MessagesFactory.java
@@ -12,6 +12,8 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import static java.lang.String.format;
+
 class MessagesFactory {
     private final static Logger log = Logger.getLogger(MessagesFactory.class);
     private static final MessagesFactory instance = new MessagesFactory();
@@ -86,6 +88,7 @@ class MessagesFactory {
         }
     }
 
+    @SuppressWarnings("unchecked")
     private void findAndInitMessageTypes() {
         Reflections reflections = new Reflections("");
         Set<Class<?>> typesAnnotatedWith = reflections.getTypesAnnotatedWith(MessageSpec.class);
@@ -94,8 +97,8 @@ class MessagesFactory {
             if (Message.class.isAssignableFrom(clazz)) {
                 registerMessage((Class<? extends Message>) clazz);
             } else {
-                log.warn("Class "+clazz.getName()+" is annotated with "+MessageSpec.class.getName()+", however it does" +
-                        "not extend "+Message.class.getName()+".");
+                log.warn(format("Class %s is annotated with %s, however it does not extend %s", clazz.getName(),
+                        MessageSpec.class.getName(), Message.class.getName()));
             }
         }
     }
@@ -121,7 +124,7 @@ class MessagesFactory {
             attributeConstructors.put(spec, constructor);
             return true;
         } catch (NoSuchMethodException e) {
-            log.debug("Class "+clazz.getName()+" does not have a constructor accepting "+KeyValuePair.class.getName()+"+.");
+            log.debug(format("Class %s does not have a constructor accepting %s", clazz.getName(), KeyValuePair.class.getName()));
             return false;
         }
     }
@@ -133,8 +136,8 @@ class MessagesFactory {
             noAttributeConstructors.put(spec, constructor);
             return true;
         } catch (NoSuchMethodException e) {
-            log.error("Error while searching for message types. Does the " + clazz.getName()
-                    + " have a constructor with " + MessageAddress.class.getName() + " as an argument?", e);
+            log.error(format("Error while searching for message types. Does the %s have a constructor with %s as an argument?",
+                    clazz.getName(), MessageAddress.class.getName()), e);
             return false;
         }
     }

--- a/stabilizer/src/main/java/com/hazelcast/stabilizer/communicator/Communicator.java
+++ b/stabilizer/src/main/java/com/hazelcast/stabilizer/communicator/Communicator.java
@@ -15,7 +15,7 @@ import static com.hazelcast.stabilizer.utils.FileUtils.getStablizerHome;
 import static java.lang.String.format;
 
 public class Communicator {
-    private final static Logger log = Logger.getLogger(Communicator.class.getName());
+    private final static Logger log = Logger.getLogger(Communicator.class);
     private final static String STABILIZER_HOME = getStablizerHome().getAbsolutePath();
 
     public File agentsFile;

--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/concurrent/lock/LockConflictTest.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/concurrent/lock/LockConflictTest.java
@@ -28,7 +28,7 @@ public class LockConflictTest {
     private final static ILogger log = Logger.getLogger(LockConflictTest.class);
 
     // properties.
-    public String basename = this.getClass().getName();
+    public String basename = this.getClass().getSimpleName();
     public int threadCount = 3;
     public int keyCount = 50;
     public int maxKeysPerTxn = 5;

--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/concurrent/lock/SimpleLockTest.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/concurrent/lock/SimpleLockTest.java
@@ -22,7 +22,7 @@ public class SimpleLockTest {
 
     private final static ILogger log = Logger.getLogger(SimpleLockTest.class);
 
-    public String basename = this.getClass().getName();
+    public String basename = this.getClass().getSimpleName();
     public int maxAccounts = 7;
     public int threadCount = 10;
 

--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/executor/ExecutorTest.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/executor/ExecutorTest.java
@@ -51,7 +51,7 @@ public class ExecutorTest {
     //the number of outstanding submits, before doing get. A count of 1 means that you wait for every task
     //to complete, before sending in the next.
     public int submitCount = 5;
-    public String basename = this.getClass().getName();
+    public String basename = this.getClass().getSimpleName();
 
     private IExecutorService[] executors;
     private IAtomicLong executedCounter;

--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/icache/EntryProcessorICacheTest.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/icache/EntryProcessorICacheTest.java
@@ -39,7 +39,7 @@ public class EntryProcessorICacheTest {
     private final static ILogger log = Logger.getLogger(EntryProcessorICacheTest.class);
 
     //props
-    public String basename = this.getClass().getName();
+    public String basename = this.getClass().getSimpleName();
     public int threadCount = 10;
     public int keyCount = 1000;
     public int minProcessorDelayMs = 0;

--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/map/MapEntryProcessorTest.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/map/MapEntryProcessorTest.java
@@ -30,7 +30,7 @@ public class MapEntryProcessorTest {
     private static final ILogger log = Logger.getLogger(MapEntryProcessorTest.class);
 
     // properties
-    public String basename = this.getClass().getName();
+    public String basename = this.getClass().getSimpleName();
     public int threadCount = 10;
     public int keyCount = 1000;
     public int minProcessorDelayMs = 0;

--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/map/MapHeapHogTest.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/map/MapHeapHogTest.java
@@ -23,7 +23,7 @@ public class MapHeapHogTest {
     private final static ILogger log = Logger.getLogger(MapHeapHogTest.class);
 
     // properties
-    public String basename = this.getClass().getName();
+    public String basename = this.getClass().getSimpleName();
     public int threadCount = 3;
     public int ttlHours = 24;
     public double approxHeapUsageFactor = 0.9;

--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/map/MapPredicateTest.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/map/MapPredicateTest.java
@@ -45,7 +45,7 @@ public class MapPredicateTest {
 
     private static final ILogger log = Logger.getLogger(MapPredicateTest.class);
 
-    public String basename = this.getClass().getName();
+    public String basename = this.getClass().getSimpleName();
     public int threadCount = 3;
     public int keyCount = 100;
     public int pageSize = 5;

--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/map/MapStoreTest.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/map/MapStoreTest.java
@@ -33,7 +33,7 @@ public class MapStoreTest {
 
     private final static ILogger log = Logger.getLogger(MapStoreTest.class);
 
-    public String basename = this.getClass().getName();
+    public String basename = this.getClass().getSimpleName();
     public int threadCount = 3;
     public int keyCount = 10;
 

--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/map/MapTimeToLiveTest.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/map/MapTimeToLiveTest.java
@@ -46,7 +46,7 @@ public class MapTimeToLiveTest {
     private final static ILogger log = Logger.getLogger(MapTimeToLiveTest.class);
 
     // properties
-    public String basename = this.getClass().getName();
+    public String basename = this.getClass().getSimpleName();
     public int threadCount = 3;
     public int keyCount = 10;
 

--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/map/MapTransactionContextConflictTest.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/map/MapTransactionContextConflictTest.java
@@ -32,7 +32,7 @@ import static org.junit.Assert.assertEquals;
 public class MapTransactionContextConflictTest {
     private final static ILogger log = Logger.getLogger(MapTransactionContextConflictTest.class);
 
-    public String basename = this.getClass().getName();
+    public String basename = this.getClass().getSimpleName();
     public int threadCount = 3;
     public int keyCount = 50;
     public int maxKeysPerTxn = 5;

--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/map/MapTransactionContextTest.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/map/MapTransactionContextTest.java
@@ -31,7 +31,7 @@ public class MapTransactionContextTest {
     private final static ILogger log = Logger.getLogger(MapTransactionContextTest.class);
 
     // properties
-    public String basename = this.getClass().getName();
+    public String basename = this.getClass().getSimpleName();
     public int threadCount = 3;
     public int keyCount = 10;
     public boolean rethrowAllException=false;

--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/map/MapTransactionTest.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/map/MapTransactionTest.java
@@ -31,7 +31,7 @@ public class MapTransactionTest {
     private final static ILogger log = Logger.getLogger(MapTransactionTest.class);
 
     // properties
-    public String basename = this.getClass().getName();
+    public String basename = this.getClass().getSimpleName();
     public int threadCount = 5;
     public int keyCount = 1000;
 

--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/map/SplitClusterDataTest.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/map/SplitClusterDataTest.java
@@ -18,7 +18,7 @@ public class SplitClusterDataTest {
 
     private final static ILogger log = Logger.getLogger(SplitClusterDataTest.class);
 
-    public String basename = this.getClass().getName();
+    public String basename = this.getClass().getSimpleName();
     public int maxItems = 10000;
     public int clusterSize = -1;
     public int splitClusterSize = -1;

--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/queue/QueueTest.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/queue/QueueTest.java
@@ -43,7 +43,7 @@ public class QueueTest {
     public int queueLength = 100;
     public int threadsPerQueue = 1;
     public int messagesPerQueue = 1;
-    public String basename = this.getClass().getName();
+    public String basename = this.getClass().getSimpleName();
     private TestContext testContext;
 
     @Setup

--- a/tests/src/main/java/com/hazelcast/stabilizer/tests/queue/TxnQueueWithLockTest.java
+++ b/tests/src/main/java/com/hazelcast/stabilizer/tests/queue/TxnQueueWithLockTest.java
@@ -25,7 +25,7 @@ public class TxnQueueWithLockTest {
 
     private final static ILogger log = Logger.getLogger(TxnQueueWithLockTest.class);
 
-    public String basename = this.getClass().getName();
+    public String basename = this.getClass().getSimpleName();
     public int threadCount = 5;
 
     private HazelcastInstance instance = null;


### PR DESCRIPTION
Cleanup and possible bug in Hazelcast 3.5 due to new config pattern matcher (configs may not get fetched with full class identifier, but simple class name).